### PR TITLE
解除网易云音乐歌单1000首限制，添加网易云音乐逐字歌词解析功能

### DIFF
--- a/index.php
+++ b/index.php
@@ -48,6 +48,11 @@ if (in_array($type, ['song', 'playlist', 'search'])) {
 header('Access-Control-Allow-Origin: *');
 header('Access-Control-Allow-Methods: GET');
 
+// 禁止搜索引擎索引带参数的 URL
+if (!empty($_GET)) {
+    header("X-Robots-Tag: noindex, nofollow", true);
+}
+
 // 强制 HTTPS 重定向（在定义 Only_Https 后立即添加）
 if (defined('Only_Https') && Only_Https === true) {
     // 检测是否为 HTTPS 请求（支持反向代理）

--- a/index.php
+++ b/index.php
@@ -1,13 +1,11 @@
 <?php
 // 设置API路径
 define('API_URI', api_uri());
-// 设置中文歌词
-define('TLYRIC', true);
+// 设置仅 Https
+define('Only_Https', true);
 // 设置歌单文件缓存及时间
 define('CACHE', false);
 define('CACHE_TIME', 86400);
-// 设置短期缓存-需要安装apcu
-define('APCU_CACHE', false);
 // 设置AUTH密钥-更改'meting-secret'
 define('AUTH', false);
 define('AUTH_SECRET', 'meting-secret');
@@ -24,7 +22,9 @@ $br = filter_input(INPUT_GET, 'br', FILTER_SANITIZE_SPECIAL_CHARS) ?: '2147483';
 $dwrc = filter_input(INPUT_GET, 'dwrc', FILTER_SANITIZE_SPECIAL_CHARS) ?: 'false';
 $yrc = filter_input(INPUT_GET, 'yrc', FILTER_SANITIZE_SPECIAL_CHARS) ?: 'false';
 $qrc = filter_input(INPUT_GET, 'qrc', FILTER_SANITIZE_SPECIAL_CHARS) ?: 'false';
+$trlrc = filter_input(INPUT_GET, 'trlrc', FILTER_SANITIZE_SPECIAL_CHARS) ?: 'false';
 $picsize = filter_input(INPUT_GET, 'picsize', FILTER_SANITIZE_SPECIAL_CHARS) ?: null;
+$info = filter_input(INPUT_GET, 'info', FILTER_SANITIZE_SPECIAL_CHARS) ?: 'false';
 
 
 if (AUTH) {
@@ -42,11 +42,26 @@ if (in_array($type, ['song', 'playlist', 'search'])) {
     header('content-type: application/json; charset=utf-8;');
 } else if (in_array($type, ['name', 'lrc', 'artist'])) {
     header('content-type: text/plain; charset=utf-8;');
-}
+};
 
 // 允许跨站
 header('Access-Control-Allow-Origin: *');
 header('Access-Control-Allow-Methods: GET');
+
+// 强制 HTTPS 重定向（在定义 Only_Https 后立即添加）
+if (defined('Only_Https') && Only_Https === true) {
+    // 检测是否为 HTTPS 请求（支持反向代理）
+    $is_https = (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] === 'on' || $_SERVER['HTTPS'] == 1))
+        || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] === 'https');
+
+    // 如果是 HTTP 请求，则重定向到 HTTPS
+    if (!$is_https) {
+        $https_url = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+        header('HTTP/1.1 302 Found');
+        header('Location: ' . $https_url);
+        exit;
+    }
+}
 
 // include __DIR__ . '/vendor/autoload.php';
 // you can use 'Meting.php' instead of 'autoload.php'
@@ -112,27 +127,56 @@ if ($type == 'playlist') {
 
     $data = $api->playlist($id);
     if ($data == '[]') {
-        echo '{"error":"id 为空，无法处理"}';
+        echo '{"error":"id 为空,无法处理"}';
         exit;
     }
     $data = json_decode($data);
+
+    // 修复:处理可能存在的额外数字索引层
+    if (is_object($data) && isset($data->{'0'})) {
+        // 如果是对象且有数字键,转换为数组
+        $data = json_decode(json_encode($data), true);
+        $data = array_values($data);
+    } elseif (is_array($data) && count($data) > 0 && isset($data[0]) && !isset($data[0]->name)) {
+        // 如果第一个元素不是歌曲对象,可能需要展平
+        $data = array_values($data);
+    }
+
     $playlist = array();
     foreach ($data as $song) {
+        // 处理可能是数组的情况
+        if (is_array($song)) {
+            $song = (object)$song;
+        }
+
         $lrc_url = API_URI . '?server=' . $song->source . '&type=lrc&id=' . $song->lyric_id . (AUTH ? '&auth=' . auth($song->source . 'lrc' . $song->lyric_id) : '');
         if ($dwrc == 'true') {
             $lrc_url .= '&dwrc=true';
         }
 
-        $playlist[] = array(
+        $item = array(
             'name'   => $song->name,
-            'artist' => implode('/', $song->artist),
+            'artist' => implode('/', (array)$song->artist),
+            'album'  => $song->album ?? '',
             'url'    => API_URI . '?server=' . $song->source . '&type=url&id=' . $song->url_id . (AUTH ? '&auth=' . auth($song->source . 'url' . $song->url_id) : ''),
             'pic'    => API_URI . '?server=' . $song->source . '&type=pic&id=' . $song->pic_id . (AUTH ? '&auth=' . auth($song->source . 'pic' . $song->pic_id) : ''),
             'lrc'    => $lrc_url
         );
+
+        if (!empty($song->duration)) {
+            $item['duration'] = $song->duration;
+        }
+        if (!empty($song->mv_id)) {
+            $item['mv_id'] = $song->mv_id;
+        }
+        if (!empty($song->fee)) {
+            $item['fee'] = $song->fee;
+        }
+
+        $playlist[] = $item;
     }
 
-    $playlist = json_encode($playlist);
+    $playlist = json_encode($playlist, JSON_UNESCAPED_UNICODE);
 
     if (CACHE) {
         // ! mkdir /cache/playlist
@@ -167,20 +211,79 @@ if ($type == 'playlist') {
             $lrc_url .= '&dwrc=true';
         }
 
-        $search[] = array(
+        $entry = array(
             'name'   => $song['name'],
             'artist' => implode('/', $song['artist']),
-            'album'  => $song['album'],
+            'album'  => $song['album'] ?? '',
             'url'    => API_URI . '?server=' . $song['source'] . '&type=url&id=' . $song['url_id'] . (AUTH ? '&auth=' . auth($song['source'] . 'url' . $song['url_id']) : ''),
             'pic'    => API_URI . '?server=' . $song['source'] . '&type=pic&id=' . $song['pic_id'] . (AUTH ? '&auth=' . auth($song['source'] . 'pic' . $song['pic_id']) : ''),
             'lrc'    => $lrc_url,
             'source' => $song['source']
         );
+        if (!empty($song['duration'])) {
+            $entry['duration'] = $song['duration'];
+        }
+        if (!empty($song['mv_id'])) {
+            $entry['mv_id'] = $song['mv_id'];
+        }
+        if (!empty($song['fee'])) {
+            $entry['fee'] = $song['fee'];
+        }
+        $search[] = $entry;
     }
 
     $search = json_encode($search, JSON_UNESCAPED_UNICODE);
     header('Content-Type: application/json; charset=utf-8');
     echo $search;
+    exit;
+} else if ($type == 'mv') {
+    // MV 功能
+    if ($info == 'true') {
+        // 返回 JSON 格式的完整信息
+        $mv_data_json = $api->mv($id, true);
+        $mv_data = json_decode($mv_data_json, true);
+
+        // 转换所有 URL 为 HTTPS
+        if (isset($mv_data['url'])) {
+            $mv_data['url'] = convert_to_https($mv_data['url']);
+        }
+        if (isset($mv_data['cover'])) {
+            $mv_data['cover'] = convert_to_https($mv_data['cover']);
+        }
+
+        header('Content-Type: application/json; charset=utf-8');
+        echo json_encode($mv_data, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+    } else {
+        // 返回纯 URL 进行 302 跳转
+        $mv_url = $api->mv($id, false);
+        if (!empty($mv_url) && $mv_url != 'null' && $mv_url != null) {
+            $mv_url = convert_to_https($mv_url);
+            header('HTTP/1.1 302 Temporary Redirect');
+            header('Location: ' . $mv_url);
+        } else {
+            echo '{"error":"MV URL not found"}';
+        }
+    }
+    exit;
+} else if ($type == 'comment') {
+    // 评论功能
+    $limit = filter_input(INPUT_GET, 'limit', FILTER_SANITIZE_SPECIAL_CHARS) ?: 20;
+    $offset = filter_input(INPUT_GET, 'offset', FILTER_SANITIZE_SPECIAL_CHARS) ?: 0;
+
+    $comment_data = $api->comment($id, $limit, $offset);
+    $comment_data = str_replace('http://', 'https://', $comment_data);
+    header('Content-Type: application/json; charset=utf-8');
+    echo $comment_data;
+    exit;
+} else if ($type == 'mvcomment') {
+    // MV 评论功能
+    $limit = filter_input(INPUT_GET, 'limit', FILTER_SANITIZE_SPECIAL_CHARS) ?: 20;
+    $offset = filter_input(INPUT_GET, 'offset', FILTER_SANITIZE_SPECIAL_CHARS) ?: 0;
+
+    $mvcomment_data = $api->mvcomment($id, $limit, $offset);
+    $mvcomment_data = str_replace('http://', 'https://', $mvcomment_data);
+    header('Content-Type: application/json; charset=utf-8');
+    echo $mvcomment_data;
     exit;
 } else {
     $need_song = !in_array($type, ['url', 'pic', 'lrc']);
@@ -189,37 +292,15 @@ if ($type == 'playlist') {
         exit;
     }
 
-    if (APCU_CACHE) {
-        $apcu_time = $type == 'url' ? 600 : 36000;
-        $apcu_type_key = $server . $type . $id;
-        if (apcu_exists($apcu_type_key)) {
-            $data = apcu_fetch($apcu_type_key);
-            return_data($type, $data);
-        }
-        if ($need_song) {
-            $apcu_song_id_key = $server . 'song_id' . $id;
-            if (apcu_exists($apcu_song_id_key)) {
-                $song = apcu_fetch($apcu_song_id_key);
-            }
-        }
-    }
-
     if (!$need_song) {
-        $data = song2data($api, null, $type, $id, $dwrc, $picsize, $br);
+        $data = song2data($api, null, $type, $id, $dwrc, $picsize, $br, $trlrc);
     } else {
         if (!isset($song)) $song = $api->song($id);
         if ($song == '[]') {
             echo '{"error":"unknown song"}';
             exit;
         }
-        if (APCU_CACHE) {
-            apcu_store($apcu_song_id_key, $song, $apcu_time);
-        }
-        $data = song2data($api, json_decode($song)[0], $type, $id, $dwrc, $picsize, $br);
-    }
-
-    if (APCU_CACHE) {
-        apcu_store($apcu_type_key, $data, $apcu_time);
+        $data = song2data($api, json_decode($song)[0], $type, $id, $dwrc, $picsize, $br, $trlrc);
     }
 
     return_data($type, $data);
@@ -241,7 +322,29 @@ function auth($name)
     return hash_hmac('sha1', $name, AUTH_SECRET);
 }
 
-function song2data($api, $song, $type, $id, $dwrc, $picsize, $br)
+function convert_to_https($url)
+{
+    if (empty($url)) {
+        return $url;
+    }
+
+    // 网易云音乐特殊处理
+    if (strlen($url) > 4 && $url[4] != 's' && strpos($url, 'http') === 0) {
+        $url = str_replace('http', 'https', $url);
+    }
+
+    // 通用 HTTP 转 HTTPS
+    if (strpos($url, 'http://') === 0) {
+        $url = str_replace('http://', 'https://', $url);
+    } elseif (strpos($url, 'https://') !== 0 && strpos($url, '://') !== false) {
+        // 处理其他协议开头的 URL
+        $url = 'https://' . ltrim($url, ':/');
+    }
+
+    return $url;
+}
+
+function song2data($api, $song, $type, $id, $dwrc, $picsize, $br, $trlrc)
 {
     $data = '';
     switch ($type) {
@@ -278,12 +381,26 @@ function song2data($api, $song, $type, $id, $dwrc, $picsize, $br)
             break;
 
         case 'lrc':
-            $lrc_data = json_decode($api->lyric($id));
-            if ($lrc_data->lyric == '') {
+            $lrc_json = $api->lyric($id);
+            $lrc_data = json_decode($lrc_json);
+            if (!$lrc_data || (!isset($lrc_data->lyric) && !isset($lrc_data->tlyric))) {
                 $lrc = '';
+            } else if ($trlrc == 'only' && $dwrc == 'false') {
+                if ($lrc_data->tlyric == '') {
+                    $lrc = '';
+                } else {
+                    $lrc_cn_arr = explode("\n", $lrc_data->tlyric);
+                    foreach ($lrc_cn_arr as $i => $v) {
+                        if ($v == '') continue;
+                        $line = explode(']', $v, 2);
+                        $line[1] = isset($line[1]) ? trim(preg_replace('/\s\s+/', ' ', $line[1] ?? '')) : '';
+                        $lrc_cn_arr[$i] = $line[0] . ']' . $line[1];
+                    }
+                    $lrc = implode("\n", $lrc_cn_arr);
+                }
             } else if ($lrc_data->tlyric == '') {
                 $lrc = $lrc_data->lyric;
-            } else if (TLYRIC) { // lyric_cn
+            } else if ($trlrc == 'true' && $dwrc == 'false') { // lyric_cn
                 $lrc_arr = explode("\n", $lrc_data->lyric);
                 $lrc_cn_arr = explode("\n", $lrc_data->tlyric);
                 $lrc_cn_map = array();
@@ -316,13 +433,25 @@ function song2data($api, $song, $type, $id, $dwrc, $picsize, $br)
                 $lrc_url .= '&dwrc=true';
             }
 
-            $data = json_encode(array(array(
+            $data = array(
                 'name'   => $song->name,
                 'artist' => implode('/', $song->artist),
+                'album'  => $song->album ?? '',
                 'url'    => API_URI . '?server=' . $song->source . '&type=url&id=' . $song->url_id . (AUTH ? '&auth=' . auth($song->source . 'url' . $song->url_id) : ''),
                 'pic'    => API_URI . '?server=' . $song->source . '&type=pic&id=' . $song->pic_id . (AUTH ? '&auth=' . auth($song->source . 'pic' . $song->pic_id) : ''),
-                'lrc'    => $lrc_url
-            )));
+                'lrc'    => $lrc_url,
+                'source' => $song->source
+            );
+            if (!empty($song->duration)) {
+                $data['duration'] = $song->duration;
+            };
+            if (!empty($song->mv_id)) {
+                $data['mv_id'] = $song->mv_id;
+            };
+            if (!empty($song->fee)) {
+                $data['fee'] = $song->fee;
+            };
+            $data = json_encode(array($data));
             break;
     }
     if ($data == '') exit;

--- a/public/index.php
+++ b/public/index.php
@@ -64,7 +64,7 @@
         await initPlayer();
     });
 </script>
-    
+
 <body>
     <div id="aplayer"></div>
     <h1>Meting-API</h1>
@@ -87,7 +87,11 @@
     &nbsp;&nbsp;&nbsp;id: 类型ID（封面ID/单曲ID/歌单ID）<br />
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;（id 必须指定，在使用其它功能 比如搜索 时，请将 id 指定为 0 ）<br />
     <br />
+    &nbsp;&nbsp;&nbsp;picsize: 歌曲封面大小（仅使用封面功能时 可选 携带，指定纯数字）<br />
+    <br />
     &nbsp;&nbsp;&nbsp;keyword: 搜索关键词（仅使用搜索功能时携带）<br />
+    <br />
+    &nbsp;&nbsp;&nbsp;br: 歌曲最高音质（仅使用单曲功能时 可选 携带，目前仅网易云有效，指定纯数字，如 1411 即 1411kbps ）<br />
     <br />
     &nbsp;&nbsp;&nbsp;yrc: 网易云音乐逐字歌词解析开关，开启后优先解析逐字歌词。<br />
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;False 禁用(默认)<br />

--- a/public/index.php
+++ b/public/index.php
@@ -23,6 +23,10 @@
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;song 单曲<br />
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;playlist 歌单<br /><br />
     id: 类型ID（封面ID/单曲ID/歌单ID）<br />
+    <br /><br />
+    yrc: 网易云音乐逐字歌词解析开关，开启后优先解析逐字歌词。<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;False 禁用(默认)<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;True 启用<br />
     <br />
     GitHub：<a href="https://github.com/injahow/meting-api" target="_blank">meting-api</a>，此API基于 <a href="https://github.com/metowolf/Meting" target="_blank">Meting</a> 构建。<br /><br />
     例如：<a href="<?php echo API_URI ?>?type=url&id=416892104" target="_blank"><?php echo API_URI ?>?type=url&id=416892104</a><br />

--- a/public/index.php
+++ b/public/index.php
@@ -44,7 +44,7 @@
     };
 
     const initPlayer = async () => {
-        const playlist = await getPlayerList('netease', 'playlist', '3035221869');
+        const playlist = await getPlayerList('netease', 'playlist', '2619366284');
 
         const ap = new APlayer({
             container: document.getElementById('aplayer'),

--- a/public/index.php
+++ b/public/index.php
@@ -5,33 +5,99 @@
     <meta http-equiv="Content-Type" content="text/html;charset=utf-8" />
     <link rel="shortcut icon" href="favicon.png">
     <title>Meting-API</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aplayer/1.10.1/APlayer.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/aplayer/1.10.1/APlayer.min.js"></script>
 </head>
 
+<script>
+    const getPlayerList = async (server, type, id, yrc) => {
+        const res = await fetch(
+            `<?php echo API_URI ?>?server=netease&type=playlist&id=2619366284&yrc=false`,
+        );
+        const data = await res.json();
+
+        if (data[0].url.startsWith("@")) {
+            // eslint-disable-next-line no-unused-vars
+            const [handle, jsonpCallback, jsonpCallbackFunction, url] = data[0].url.split("@").slice(1);
+            const jsonpData = await fetchJsonp(url).then((res) => res.json());
+            const domain = (
+                jsonpData.req_0.data.sip.find((i) => !i.startsWith("http://ws")) ||
+                jsonpData.req_0.data.sip[0]
+            ).replace("http://", "https://");
+
+            return data.map((v, i) => ({
+                name: v.name || v.title,
+                artist: v.artist || v.author,
+                url: domain + jsonpData.req_0.data.midurlinfo[i].purl,
+                cover: v.cover || v.pic,
+                lrc: v.lrc,
+            }));
+        } else {
+            return data.map((v) => ({
+                name: v.name || v.title,
+                artist: v.artist || v.author,
+                url: v.url,
+                cover: v.cover || v.pic,
+                lrc: v.lrc,
+            }));
+        }
+    };
+
+    const initPlayer = async () => {
+        const playlist = await getPlayerList('netease', 'playlist', '3035221869');
+
+        const ap = new APlayer({
+            container: document.getElementById('aplayer'),
+            audio: playlist,
+            autoplay: true,
+            fixed: true,
+            volume: 0.7,
+            mutex: true,
+            loop: "all",
+            order: "random",
+            preload: "auto",
+            lrcType: 3,
+        });
+    };
+
+    window.addEventListener('DOMContentLoaded', async () => {
+        await initPlayer();
+    });
+</script>
+    
 <body>
+    <div id="aplayer"></div>
+    <h1>Meting-API</h1>
     <h2>参数说明</h2>
-    server: 数据源
+    &nbsp;&nbsp;&nbsp;server: 数据源
     <br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;netease 网易云音乐(默认)<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tencent QQ音乐<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;netease 网易云音乐(默认)<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tencent QQ音乐<br />
     <br />
-    type: 类型<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name 歌曲名<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;artist 歌手<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;url 链接<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pic 封面<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lrc 歌词<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;song 单曲<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;playlist 歌单<br /><br />
-    id: 类型ID（封面ID/单曲ID/歌单ID）<br />
+    &nbsp;&nbsp;&nbsp;type: 类型<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name 歌曲名<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;artist 歌手<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;url 链接<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pic 封面<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lrc 歌词<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;song 单曲<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;playlist 歌单<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;search 搜索<br />
+    <br />
+    &nbsp;&nbsp;&nbsp;id: 类型ID（封面ID/单曲ID/歌单ID）<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;（id 必须指定，在使用其它功能 比如搜索 时，请将 id 指定为 0 ）<br />
+    <br />
+    &nbsp;&nbsp;&nbsp;keyword: 搜索关键词（仅使用搜索功能时携带）<br />
+    <br />
+    &nbsp;&nbsp;&nbsp;yrc: 网易云音乐逐字歌词解析开关，开启后优先解析逐字歌词。<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;False 禁用(默认)<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;True 启用<br />
     <br /><br />
-    yrc: 网易云音乐逐字歌词解析开关，开启后优先解析逐字歌词。<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;False 禁用(默认)<br />
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;True 启用<br />
-    <br />
-    GitHub：<a href="https://github.com/injahow/meting-api" target="_blank">meting-api</a>，此API基于 <a href="https://github.com/metowolf/Meting" target="_blank">Meting</a> 构建。<br /><br />
-    例如：<a href="<?php echo API_URI ?>?type=url&id=416892104" target="_blank"><?php echo API_URI ?>?type=url&id=416892104</a><br />
-    <a href="<?php echo API_URI ?>?type=song&id=591321" target="_blank" style="padding-left:48px"><?php echo API_URI ?>?type=song&id=591321</a><br />
-    <a href="<?php echo API_URI ?>?type=playlist&id=2619366284" target="_blank" style="padding-left:48px"><?php echo API_URI ?>?type=playlist&id=2619366284</a>
+    GitHub：<a href="https://github.com/injahow/meting-api" target="_blank">meting-api</a>，此API基于 <a href="https://github.com/metowolf/Meting" target="_blank">Meting</a> 构建。当前为<a href="https://github.com/NanoRocky/meting-api" target="_blank">酪灰修改版本</a>。<br /><br /><br />
+    例如：<a href="<?php echo API_URI ?>?server=netease&type=url&id=416892104" target="_blank"><?php echo API_URI ?>?server=netease&type=url&id=416892104</a><br />
+    <a href="<?php echo API_URI ?>?server=netease&type=song&id=591321" target="_blank" style="padding-left:48px"><?php echo API_URI ?>?server=netease&type=song&id=591321</a><br />
+    <a href="<?php echo API_URI ?>?server=netease&type=playlist&id=2619366284&yrc=true" target="_blank" style="padding-left:48px"><?php echo API_URI ?>?server=netease&type=playlist&id=2619366284&yrc=true</a><br />
+    <a href="<?php echo API_URI ?>?server=netease&type=search&id=0&yrc=true&keyword=寄往未来的信" target="_blank" style="padding-left:48px"><?php echo API_URI ?>?server=netease&type=search&id=0&yrc=true&keyword=寄往未来的信</a><br />
 </body>
 
 </html>

--- a/public/index.php
+++ b/public/index.php
@@ -96,6 +96,7 @@
     &nbsp;&nbsp;&nbsp;yrc: 网易云音乐逐字歌词解析开关，开启后优先解析逐字歌词。<br />
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;False 禁用(默认)<br />
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;True 启用<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Open 备用启用模式（该模式在没有逐字歌词时不会返回逐行歌词，而是返回空）<br />
     <br /><br />
     GitHub：<a href="https://github.com/injahow/meting-api" target="_blank">meting-api</a>，此API基于 <a href="https://github.com/metowolf/Meting" target="_blank">Meting</a> 构建。当前为<a href="https://github.com/NanoRocky/meting-api" target="_blank">酪灰修改版本</a>。<br /><br /><br />
     例如：<a href="<?php echo API_URI ?>?server=netease&type=url&id=416892104" target="_blank"><?php echo API_URI ?>?server=netease&type=url&id=416892104</a><br />

--- a/public/index.php
+++ b/public/index.php
@@ -7,6 +7,7 @@
     <title>Meting-API</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aplayer/1.10.1/APlayer.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/aplayer/1.10.1/APlayer.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fetch-jsonp/build/fetch-jsonp.min.js"></script>
 </head>
 
 <script>
@@ -91,12 +92,17 @@
     <br />
     &nbsp;&nbsp;&nbsp;keyword: 搜索关键词（仅使用搜索功能时携带）<br />
     <br />
-    &nbsp;&nbsp;&nbsp;br: 歌曲最高音质（仅使用单曲功能时 可选 携带，目前仅网易云有效，指定纯数字，如 1411 即 1411kbps ）<br />
+    &nbsp;&nbsp;&nbsp;br: 歌曲最高音质（仅使用单曲功能时 可选 携带，指定纯数字，如 1411 即 1411kbps ）<br />
     <br />
-    &nbsp;&nbsp;&nbsp;yrc: 网易云音乐逐字歌词解析开关，开启后优先解析逐字歌词。<br />
+    &nbsp;&nbsp;&nbsp;dwrc: 【DynamicWordRC】逐字歌词解析开关，开启后优先解析逐字歌词。<br />
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;False 禁用(默认)<br />
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;True 启用<br />
     &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Open 备用启用模式（该模式在没有逐字歌词时不会返回逐行歌词，而是返回空）<br />
+    <br />
+    &nbsp;&nbsp;&nbsp;trlrc: 【TranslateLRC】翻译歌词显示开关（仅逐行歌词支持）。<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;False 禁用(默认)<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;True 启用<br />
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Only 仅输出翻译歌词<br />
     <br /><br />
     GitHub：<a href="https://github.com/injahow/meting-api" target="_blank">meting-api</a>，此API基于 <a href="https://github.com/metowolf/Meting" target="_blank">Meting</a> 构建。当前为<a href="https://github.com/NanoRocky/meting-api" target="_blank">酪灰修改版本</a>。<br /><br /><br />
     例如：<a href="<?php echo API_URI ?>?server=netease&type=url&id=416892104" target="_blank"><?php echo API_URI ?>?server=netease&type=url&id=416892104</a><br />

--- a/src/Meting.php
+++ b/src/Meting.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Meting music framework
  * https://i-meto.com
@@ -28,7 +29,8 @@ class Meting
     public $header;
     private $temp;
 
-    public function yrc($value = false) {
+    public function yrc($value = false)
+    {
         $this->yrc = $value;
         return $this;
     }
@@ -75,7 +77,7 @@ class Meting
         }
         if ($api['method'] == 'GET') {
             if (isset($api['body'])) {
-                $api['url'] .= '?'.http_build_query($api['body']);
+                $api['url'] .= '?' . http_build_query($api['body']);
                 $api['body'] = null;
             }
         }
@@ -101,7 +103,7 @@ class Meting
     private function curl($url, $payload = null, $headerOnly = 0)
     {
         $header = array_map(function ($k, $v) {
-            return $k.': '.$v;
+            return $k . ': ' . $v;
         }, array_keys($this->header), $this->header);
         $curl = curl_init();
         if (!is_null($payload)) {
@@ -156,7 +158,7 @@ class Meting
         if (!isset($raw[0]) && count($raw)) {
             $raw = array($raw);
         }
-        $result = array_map(array($this, 'format_'.$this->server), $raw);
+        $result = array_map(array($this, 'format_' . $this->server), $raw);
 
         return json_encode($result);
     }
@@ -165,105 +167,105 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'https://music.163.com/api/cloudsearch/pc',
-                'body'   => array(
-                    's'      => $keyword,
-                    'type'   => isset($option['type']) ? $option['type'] : 1,
-                    'limit'  => isset($option['limit']) ? $option['limit'] : 100000,
-                    'total'  => 'true',
-                    'offset' => isset($option['page']) && isset($option['limit']) ? ($option['page'] - 1) * $option['limit'] : 0,
-                ),
-                'encode' => 'netease_AESCBC',
-                'format' => 'result.songs',
-            );
-            break;
-            case 'tencent':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://c.y.qq.com/soso/fcgi-bin/client_search_cp',
-                'body'   => array(
-                    'format'   => 'json',
-                    'p'        => isset($option['page']) ? $option['page'] : 1,
-                    'n'        => isset($option['limit']) ? $option['limit'] : 30,
-                    'w'        => $keyword,
-                    'aggr'     => 1,
-                    'lossless' => 1,
-                    'cr'       => 1,
-                    'new_json' => 1,
-                ),
-                'format' => 'data.song.list',
-            );
-            break;
-            case 'xiami':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.search.searchservice.searchsongs/1.0/',
-                'body'   => array(
-                    'data' => array(
-                        'key'      => $keyword,
-                        'pagingVO' => array(
-                            'page'     => isset($option['page']) ? $option['page'] : 1,
-                            'pageSize' => isset($option['limit']) ? $option['limit'] : 30,
-                        ),
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://music.163.com/api/cloudsearch/pc',
+                    'body'   => array(
+                        's'      => $keyword,
+                        'type'   => isset($option['type']) ? $option['type'] : 1,
+                        'limit'  => isset($option['limit']) ? $option['limit'] : 50,
+                        'total'  => 'true',
+                        'offset' => isset($option['page']) && isset($option['limit']) ? ($option['page'] - 1) * $option['limit'] : 0,
                     ),
-                    'r' => 'mtop.alimusic.search.searchservice.searchsongs',
-                ),
-                'encode' => 'xiami_sign',
-                'format' => 'data.data.songs',
-            );
-            break;
+                    'encode' => 'netease_AESCBC',
+                    'format' => 'result.songs',
+                );
+                break;
+            case 'tencent':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://c.y.qq.com/soso/fcgi-bin/client_search_cp',
+                    'body'   => array(
+                        'format'   => 'json',
+                        'p'        => isset($option['page']) ? $option['page'] : 1,
+                        'n'        => isset($option['limit']) ? $option['limit'] : 50,
+                        'w'        => $keyword,
+                        'aggr'     => 1,
+                        'lossless' => 1,
+                        'cr'       => 1,
+                        'new_json' => 1,
+                    ),
+                    'format' => 'data.song.list',
+                );
+                break;
+            case 'xiami':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.search.searchservice.searchsongs/1.0/',
+                    'body'   => array(
+                        'data' => array(
+                            'key'      => $keyword,
+                            'pagingVO' => array(
+                                'page'     => isset($option['page']) ? $option['page'] : 1,
+                                'pageSize' => isset($option['limit']) ? $option['limit'] : 30,
+                            ),
+                        ),
+                        'r' => 'mtop.alimusic.search.searchservice.searchsongs',
+                    ),
+                    'encode' => 'xiami_sign',
+                    'format' => 'data.data.songs',
+                );
+                break;
             case 'kugou':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://mobilecdn.kugou.com/api/v3/search/song',
-                'body'   => array(
-                    'api_ver'   => 1,
-                    'area_code' => 1,
-                    'correct'   => 1,
-                    'pagesize'  => isset($option['limit']) ? $option['limit'] : 30,
-                    'plat'      => 2,
-                    'tag'       => 1,
-                    'sver'      => 5,
-                    'showtype'  => 10,
-                    'page'      => isset($option['page']) ? $option['page'] : 1,
-                    'keyword'   => $keyword,
-                    'version'   => 8990,
-                ),
-                'format' => 'data.info',
-            );
-            break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://mobilecdn.kugou.com/api/v3/search/song',
+                    'body'   => array(
+                        'api_ver'   => 1,
+                        'area_code' => 1,
+                        'correct'   => 1,
+                        'pagesize'  => isset($option['limit']) ? $option['limit'] : 30,
+                        'plat'      => 2,
+                        'tag'       => 1,
+                        'sver'      => 5,
+                        'showtype'  => 10,
+                        'page'      => isset($option['page']) ? $option['page'] : 1,
+                        'keyword'   => $keyword,
+                        'version'   => 8990,
+                    ),
+                    'format' => 'data.info',
+                );
+                break;
             case 'baidu':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
-                'body'   => array(
-                    'from'      => 'qianqianmini',
-                    'method'    => 'baidu.ting.search.merge',
-                    'isNew'     => 1,
-                    'platform'  => 'darwin',
-                    'page_no'   => isset($option['page']) ? $option['page'] : 1,
-                    'query'     => $keyword,
-                    'version'   => '11.2.1',
-                    'page_size' => isset($option['limit']) ? $option['limit'] : 30,
-                ),
-                'format' => 'result.song_info.song_list',
-            );
-            break;
-			case 'kuwo':
-			$api = array(
-				'method' => 'GET',
-				'url'    => 'http://www.kuwo.cn/api/www/search/searchMusicBykeyWord',
-				'body'   => array(
-					'key'         => $keyword,
-					'pn'          => isset($option['page']) ? $option['page'] : 1,
-					'rn'          => isset($option['limit']) ? $option['limit'] : 30,
-					'httpsStatus' => 1,
-				),
-				'format' => 'data.list',
-			);
-			break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'body'   => array(
+                        'from'      => 'qianqianmini',
+                        'method'    => 'baidu.ting.search.merge',
+                        'isNew'     => 1,
+                        'platform'  => 'darwin',
+                        'page_no'   => isset($option['page']) ? $option['page'] : 1,
+                        'query'     => $keyword,
+                        'version'   => '11.2.1',
+                        'page_size' => isset($option['limit']) ? $option['limit'] : 30,
+                    ),
+                    'format' => 'result.song_info.song_list',
+                );
+                break;
+            case 'kuwo':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://www.kuwo.cn/api/www/search/searchMusicBykeyWord',
+                    'body'   => array(
+                        'key'         => $keyword,
+                        'pn'          => isset($option['page']) ? $option['page'] : 1,
+                        'rn'          => isset($option['limit']) ? $option['limit'] : 30,
+                        'httpsStatus' => 1,
+                    ),
+                    'format' => 'data.list',
+                );
+                break;
         }
 
         return $this->exec($api);
@@ -273,81 +275,81 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'https://music.163.com/api/v3/song/detail/',
-                'body'   => array(
-                    'c' => '[{"id":'.$id.',"v":0}]',
-                ),
-                'encode' => 'netease_AESCBC',
-                'format' => 'songs',
-            );
-            break;
-            case 'tencent':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_play_single_song.fcg',
-                'body'   => array(
-                    'songmid'  => $id,
-                    'platform' => 'yqq',
-                    'format'   => 'json',
-                ),
-                'format' => 'data',
-            );
-            break;
-            case 'xiami':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.songservice.getsongdetail/1.0/',
-                'body'   => array(
-                    'data' => array(
-                        'songId' => $id,
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://music.163.com/api/v3/song/detail/',
+                    'body'   => array(
+                        'c' => '[{"id":' . $id . ',"v":0}]',
                     ),
-                    'r' => 'mtop.alimusic.music.songservice.getsongdetail',
-                ),
-                'encode' => 'xiami_sign',
-                'format' => 'data.data.songDetail',
-            );
-            break;
+                    'encode' => 'netease_AESCBC',
+                    'format' => 'songs',
+                );
+                break;
+            case 'tencent':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_play_single_song.fcg',
+                    'body'   => array(
+                        'songmid'  => $id,
+                        'platform' => 'yqq',
+                        'format'   => 'json',
+                    ),
+                    'format' => 'data',
+                );
+                break;
+            case 'xiami':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.songservice.getsongdetail/1.0/',
+                    'body'   => array(
+                        'data' => array(
+                            'songId' => $id,
+                        ),
+                        'r' => 'mtop.alimusic.music.songservice.getsongdetail',
+                    ),
+                    'encode' => 'xiami_sign',
+                    'format' => 'data.data.songDetail',
+                );
+                break;
             case 'kugou':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'http://m.kugou.com/app/i/getSongInfo.php',
-                'body'   => array(
-                    'cmd'  => 'playInfo',
-                    'hash' => $id,
-                    'from' => 'mkugou',
-                ),
-                'format' => '',
-            );
-            break;
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'http://m.kugou.com/app/i/getSongInfo.php',
+                    'body'   => array(
+                        'cmd'  => 'playInfo',
+                        'hash' => $id,
+                        'from' => 'mkugou',
+                    ),
+                    'format' => '',
+                );
+                break;
             case 'baidu':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
-                'body'   => array(
-                    'from'     => 'qianqianmini',
-                    'method'   => 'baidu.ting.song.getInfos',
-                    'songid'   => $id,
-                    'res'      => 1,
-                    'platform' => 'darwin',
-                    'version'  => '1.0.0',
-                ),
-                'encode' => 'baidu_AESCBC',
-                'format' => 'songinfo',
-            );
-            break;
-			case 'kuwo':
-			$api = array(
-				'method' => 'GET',
-				'url'    => 'http://www.kuwo.cn/api/www/music/musicInfo',
-				'body'   => array(
-					'mid'         => $id,
-					'httpsStatus' => 1,
-				),
-				'format' => 'data',
-			);
-			break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'body'   => array(
+                        'from'     => 'qianqianmini',
+                        'method'   => 'baidu.ting.song.getInfos',
+                        'songid'   => $id,
+                        'res'      => 1,
+                        'platform' => 'darwin',
+                        'version'  => '1.0.0',
+                    ),
+                    'encode' => 'baidu_AESCBC',
+                    'format' => 'songinfo',
+                );
+                break;
+            case 'kuwo':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://www.kuwo.cn/api/www/music/musicInfo',
+                    'body'   => array(
+                        'mid'         => $id,
+                        'httpsStatus' => 1,
+                    ),
+                    'format' => 'data',
+                );
+                break;
         }
 
         return $this->exec($api);
@@ -357,90 +359,90 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'https://music.163.com/api/v1/album/'.$id,
-                'body'   => array(
-                    'total'         => 'true',
-                    'offset'        => '0',
-                    'id'            => $id,
-                    'limit'         => '100000',
-                    'ext'           => 'true',
-                    'private_cloud' => 'true',
-                ),
-                'encode' => 'netease_AESCBC',
-                'format' => 'songs',
-            );
-            break;
-            case 'tencent':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_album_detail_cp.fcg',
-                'body'   => array(
-                    'albummid' => $id,
-                    'platform' => 'mac',
-                    'format'   => 'json',
-                    'newsong'  => 1,
-                ),
-                'format' => 'data.getSongInfo',
-            );
-            break;
-            case 'xiami':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.albumservice.getalbumdetail/1.0/',
-                'body'   => array(
-                    'data' => array(
-                        'albumId' => $id,
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://music.163.com/api/v1/album/' . $id,
+                    'body'   => array(
+                        'total'         => 'true',
+                        'offset'        => '0',
+                        'id'            => $id,
+                        'limit'         => '100000',
+                        'ext'           => 'true',
+                        'private_cloud' => 'true',
                     ),
-                    'r' => 'mtop.alimusic.music.albumservice.getalbumdetail',
-                ),
-                'encode' => 'xiami_sign',
-                'format' => 'data.data.albumDetail.songs',
-            );
-            break;
+                    'encode' => 'netease_AESCBC',
+                    'format' => 'songs',
+                );
+                break;
+            case 'tencent':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_album_detail_cp.fcg',
+                    'body'   => array(
+                        'albummid' => $id,
+                        'platform' => 'mac',
+                        'format'   => 'json',
+                        'newsong'  => 1,
+                    ),
+                    'format' => 'data.getSongInfo',
+                );
+                break;
+            case 'xiami':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.albumservice.getalbumdetail/1.0/',
+                    'body'   => array(
+                        'data' => array(
+                            'albumId' => $id,
+                        ),
+                        'r' => 'mtop.alimusic.music.albumservice.getalbumdetail',
+                    ),
+                    'encode' => 'xiami_sign',
+                    'format' => 'data.data.albumDetail.songs',
+                );
+                break;
             case 'kugou':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://mobilecdn.kugou.com/api/v3/album/song',
-                'body'   => array(
-                    'albumid'   => $id,
-                    'area_code' => 1,
-                    'plat'      => 2,
-                    'page'      => 1,
-                    'pagesize'  => -1,
-                    'version'   => 8990,
-                ),
-                'format' => 'data.info',
-            );
-            break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://mobilecdn.kugou.com/api/v3/album/song',
+                    'body'   => array(
+                        'albumid'   => $id,
+                        'area_code' => 1,
+                        'plat'      => 2,
+                        'page'      => 1,
+                        'pagesize'  => -1,
+                        'version'   => 8990,
+                    ),
+                    'format' => 'data.info',
+                );
+                break;
             case 'baidu':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
-                'body'   => array(
-                    'from'     => 'qianqianmini',
-                    'method'   => 'baidu.ting.album.getAlbumInfo',
-                    'album_id' => $id,
-                    'platform' => 'darwin',
-                    'version'  => '11.2.1',
-                ),
-                'format' => 'songlist',
-            );
-            break;
-			case 'kuwo':
-			$api = array(
-				'method' => 'GET',
-				'url'    => 'http://www.kuwo.cn/api/www/album/albumInfo',
-				'body'   => array(
-					'albumId'     => $id,
-                    'pn'          => 1,
-                    'rn'          => 1000,
-					'httpsStatus' => 1,
-				),
-				'format' => 'data.musicList',
-			);
-			break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'body'   => array(
+                        'from'     => 'qianqianmini',
+                        'method'   => 'baidu.ting.album.getAlbumInfo',
+                        'album_id' => $id,
+                        'platform' => 'darwin',
+                        'version'  => '11.2.1',
+                    ),
+                    'format' => 'songlist',
+                );
+                break;
+            case 'kuwo':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://www.kuwo.cn/api/www/album/albumInfo',
+                    'body'   => array(
+                        'albumId'     => $id,
+                        'pn'          => 1,
+                        'rn'          => 1000,
+                        'httpsStatus' => 1,
+                    ),
+                    'format' => 'data.musicList',
+                );
+                break;
         }
 
         return $this->exec($api);
@@ -450,98 +452,97 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'https://music.163.com/api/v1/artist/'.$id,
-                'body'   => array(
-                    'ext'           => 'true',
-                    'private_cloud' => 'true',
-                    'ext'           => 'true',
-                    'top'           => $limit,
-                    'id'            => $id,
-                ),
-                'encode' => 'netease_AESCBC',
-                'format' => 'hotSongs',
-            );
-            break;
-            case 'tencent':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_singer_track_cp.fcg',
-                'body'   => array(
-                    'singermid' => $id,
-                    'begin'     => 0,
-                    'num'       => $limit,
-                    'order'     => 'listen',
-                    'platform'  => 'mac',
-                    'newsong'   => 1,
-                ),
-                'format' => 'data.list',
-            );
-            break;
-            case 'xiami':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.songservice.getartistsongs/1.0/',
-                'body'   => array(
-                    'data' => array(
-                        'artistId' => $id,
-                        'pagingVO' => array(
-                            'page'     => 1,
-                            'pageSize' => $limit,
-                        ),
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://music.163.com/api/v1/artist/' . $id,
+                    'body'   => array(
+                        'ext'           => 'true',
+                        'private_cloud' => 'true',
+                        'top'           => $limit,
+                        'id'            => $id,
                     ),
-                    'r' => 'mtop.alimusic.music.songservice.getartistsongs',
-                ),
-                'encode' => 'xiami_sign',
-                'format' => 'data.data.songs',
-            );
-            break;
+                    'encode' => 'netease_AESCBC',
+                    'format' => 'hotSongs',
+                );
+                break;
+            case 'tencent':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_singer_track_cp.fcg',
+                    'body'   => array(
+                        'singermid' => $id,
+                        'begin'     => 0,
+                        'num'       => $limit,
+                        'order'     => 'listen',
+                        'platform'  => 'mac',
+                        'newsong'   => 1,
+                    ),
+                    'format' => 'data.list',
+                );
+                break;
+            case 'xiami':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.songservice.getartistsongs/1.0/',
+                    'body'   => array(
+                        'data' => array(
+                            'artistId' => $id,
+                            'pagingVO' => array(
+                                'page'     => 1,
+                                'pageSize' => $limit,
+                            ),
+                        ),
+                        'r' => 'mtop.alimusic.music.songservice.getartistsongs',
+                    ),
+                    'encode' => 'xiami_sign',
+                    'format' => 'data.data.songs',
+                );
+                break;
             case 'kugou':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://mobilecdn.kugou.com/api/v3/singer/song',
-                'body'   => array(
-                    'singerid'  => $id,
-                    'area_code' => 1,
-                    'page'      => 1,
-                    'plat'      => 0,
-                    'pagesize'  => $limit,
-                    'version'   => 8990,
-                ),
-                'format' => 'data.info',
-            );
-            break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://mobilecdn.kugou.com/api/v3/singer/song',
+                    'body'   => array(
+                        'singerid'  => $id,
+                        'area_code' => 1,
+                        'page'      => 1,
+                        'plat'      => 0,
+                        'pagesize'  => $limit,
+                        'version'   => 8990,
+                    ),
+                    'format' => 'data.info',
+                );
+                break;
             case 'baidu':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
-                'body'   => array(
-                    'from'     => 'qianqianmini',
-                    'method'   => 'baidu.ting.artist.getSongList',
-                    'artistid' => $id,
-                    'limits'   => $limit,
-                    'platform' => 'darwin',
-                    'offset'   => 0,
-                    'tinguid'  => 0,
-                    'version'  => '11.2.1',
-                ),
-                'format' => 'songlist',
-            );
-            break;
-			case 'kuwo':
-			$api = array(
-				'method' => 'GET',
-				'url'    => 'http://www.kuwo.cn/api/www/artist/artistMusic',
-				'body'   => array(
-					'artistid'    => $id,
-                    'pn'          => 1,
-                    'rn'          => $limit,
-					'httpsStatus' => 1,
-				),
-				'format' => 'data.list',
-			);
-			break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'body'   => array(
+                        'from'     => 'qianqianmini',
+                        'method'   => 'baidu.ting.artist.getSongList',
+                        'artistid' => $id,
+                        'limits'   => $limit,
+                        'platform' => 'darwin',
+                        'offset'   => 0,
+                        'tinguid'  => 0,
+                        'version'  => '11.2.1',
+                    ),
+                    'format' => 'songlist',
+                );
+                break;
+            case 'kuwo':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://www.kuwo.cn/api/www/artist/artistMusic',
+                    'body'   => array(
+                        'artistid'    => $id,
+                        'pn'          => 1,
+                        'rn'          => $limit,
+                        'httpsStatus' => 1,
+                    ),
+                    'format' => 'data.list',
+                );
+                break;
         }
 
         return $this->exec($api);
@@ -551,147 +552,146 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = [
-                "method" => "POST",
-                "url" => "https://music.163.com/api/v6/playlist/detail",
-                "body" => [
-                    "id" => $id,
-                    "offset" => "0",
-                    "total" => "True",
-                    "limit" => "100000",
-                    "n" => "100000",
-                ],
-                "encode" => "netease_AESCBC",
-            ];
-            $playlistData = json_decode($this->exec($api), true);
-            $trackIds = $playlistData["playlist"]["trackIds"];
-            $allTracks = [];
-            $idBatches = array_chunk(array_column($trackIds, "id"), 500);
-
-            foreach ($idBatches as $batch) {
-                // Convert the batch into the proper format
-                $songIds = array_map(function ($id) {
-                    return ["id" => $id, "v" => 0]; // Using 'v' => 0 as per your suggestion
-                }, $batch);
-
-                // Fetch the song details for each batch
-                $songApi = [
+                $api = [
                     "method" => "POST",
-                    "url" => "https://music.163.com/api/v3/song/detail/",
+                    "url" => "https://music.163.com/api/v6/playlist/detail",
                     "body" => [
-                        "c" => json_encode($songIds),
+                        "id" => $id,
+                        "offset" => "0",
+                        "total" => "True",
+                        "limit" => "100000",
+                        "n" => "100000",
                     ],
                     "encode" => "netease_AESCBC",
                 ];
-                $songData = $this->exec($songApi);
-                // Merge songs data into allTracks
-                $allTracks = array_merge(
-                    $allTracks,
-                    json_decode($songData, true)["songs"]
-                );
-            }
-            $tmp = array_map(function ($data) {
-                $result = [
-                    "id" => $data["id"],
-                    "name" => $data["name"],
-                    "artist" => [],
-                    "album" => $data["al"]["name"],
-                    "pic_id" => isset($data["al"]["pic_str"])
-                        ? $data["al"]["pic_str"]
-                        : $data["al"]["pic"],
-                    "url_id" => $data["id"],
-                    "lyric_id" => $data["id"],
-                    "source" => "netease",
-                ];
-                if (isset($data["al"]["picUrl"])) {
-                    preg_match(
-                        "/\/(\d+)\./",
-                        $data["al"]["picUrl"],
-                        $match
+                $playlistData = json_decode($this->exec($api), true);
+                $trackIds = $playlistData["playlist"]["trackIds"];
+                $allTracks = [];
+                $idBatches = array_chunk(array_column($trackIds, "id"), 500);
+
+                foreach ($idBatches as $batch) {
+                    // Convert the batch into the proper format
+                    $songIds = array_map(function ($id) {
+                        return ["id" => $id, "v" => 0]; // Using 'v' => 0 as per your suggestion
+                    }, $batch);
+
+                    // Fetch the song details for each batch
+                    $songApi = [
+                        "method" => "POST",
+                        "url" => "https://music.163.com/api/v3/song/detail/",
+                        "body" => [
+                            "c" => json_encode($songIds),
+                        ],
+                        "encode" => "netease_AESCBC",
+                    ];
+                    $songData = $this->exec($songApi);
+                    // Merge songs data into allTracks
+                    $allTracks = array_merge(
+                        $allTracks,
+                        json_decode($songData, true)["songs"]
                     );
-                    $result["pic_id"] = $match[1];
                 }
-                foreach ($data["ar"] as $vo) {
-                    $result["artist"][] = $vo["name"];
-                }
-                return $result;
-            }, $allTracks);
-            return json_encode($tmp);
-            break;
+                $tmp = array_map(function ($data) {
+                    $result = [
+                        "id" => $data["id"],
+                        "name" => $data["name"],
+                        "artist" => [],
+                        "album" => $data["al"]["name"],
+                        "pic_id" => isset($data["al"]["pic_str"])
+                            ? $data["al"]["pic_str"]
+                            : $data["al"]["pic"],
+                        "url_id" => $data["id"],
+                        "lyric_id" => $data["id"],
+                        "source" => "netease",
+                    ];
+                    if (isset($data["al"]["picUrl"])) {
+                        preg_match(
+                            "/\/(\d+)\./",
+                            $data["al"]["picUrl"],
+                            $match
+                        );
+                        $result["pic_id"] = $match[1];
+                    }
+                    foreach ($data["ar"] as $vo) {
+                        $result["artist"][] = $vo["name"];
+                    }
+                    return $result;
+                }, $allTracks);
+                return json_encode($tmp);
             case 'tencent':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_playlist_cp.fcg',
-                'body'   => array(
-                    'id'       => $id,
-                    'format'   => 'json',
-                    'newsong'  => 1,
-                    'platform' => 'jqspaframe.json',
-                ),
-                'format' => 'data.cdlist.0.songlist',
-            );
-            break;
-            case 'xiami':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.list.collectservice.getcollectdetail/1.0/',
-                'body'   => array(
-                    'data' => array(
-                        'listId'     => $id,
-                        'isFullTags' => false,
-                        'pagingVO'   => array(
-                            'page'     => 1,
-                            'pageSize' => 1000,
-                        ),
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_playlist_cp.fcg',
+                    'body'   => array(
+                        'id'       => $id,
+                        'format'   => 'json',
+                        'newsong'  => 1,
+                        'platform' => 'jqspaframe.json',
                     ),
-                    'r' => 'mtop.alimusic.music.list.collectservice.getcollectdetail',
-                ),
-                'encode' => 'xiami_sign',
-                'format' => 'data.data.collectDetail.songs',
-            );
-            break;
+                    'format' => 'data.cdlist.0.songlist',
+                );
+                break;
+            case 'xiami':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.list.collectservice.getcollectdetail/1.0/',
+                    'body'   => array(
+                        'data' => array(
+                            'listId'     => $id,
+                            'isFullTags' => false,
+                            'pagingVO'   => array(
+                                'page'     => 1,
+                                'pageSize' => 1000,
+                            ),
+                        ),
+                        'r' => 'mtop.alimusic.music.list.collectservice.getcollectdetail',
+                    ),
+                    'encode' => 'xiami_sign',
+                    'format' => 'data.data.collectDetail.songs',
+                );
+                break;
             case 'kugou':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://mobilecdn.kugou.com/api/v3/special/song',
-                'body'   => array(
-                    'specialid' => $id,
-                    'area_code' => 1,
-                    'page'      => 1,
-                    'plat'      => 2,
-                    'pagesize'  => -1,
-                    'version'   => 8990,
-                ),
-                'format' => 'data.info',
-            );
-            break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://mobilecdn.kugou.com/api/v3/special/song',
+                    'body'   => array(
+                        'specialid' => $id,
+                        'area_code' => 1,
+                        'page'      => 1,
+                        'plat'      => 2,
+                        'pagesize'  => -1,
+                        'version'   => 8990,
+                    ),
+                    'format' => 'data.info',
+                );
+                break;
             case 'baidu':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
-                'body'   => array(
-                    'from'     => 'qianqianmini',
-                    'method'   => 'baidu.ting.diy.gedanInfo',
-                    'listid'   => $id,
-                    'platform' => 'darwin',
-                    'version'  => '11.2.1',
-                ),
-                'format' => 'content',
-            );
-            break;
-			case 'kuwo':
-			$api = array(
-				'method' => 'GET',
-				'url'    => 'http://www.kuwo.cn/api/www/playlist/playListInfo',
-				'body'   => array(
-					'pid'         => $id,
-                    'pn'          => 1,
-                    'rn'          => 1000,
-					'httpsStatus' => 1,
-				),
-				'format' => 'data.musicList',
-			);
-			break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'body'   => array(
+                        'from'     => 'qianqianmini',
+                        'method'   => 'baidu.ting.diy.gedanInfo',
+                        'listid'   => $id,
+                        'platform' => 'darwin',
+                        'version'  => '11.2.1',
+                    ),
+                    'format' => 'content',
+                );
+                break;
+            case 'kuwo':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://www.kuwo.cn/api/www/playlist/playListInfo',
+                    'body'   => array(
+                        'pid'         => $id,
+                        'pn'          => 1,
+                        'rn'          => 1000,
+                        'httpsStatus' => 1,
+                    ),
+                    'format' => 'data.musicList',
+                );
+                break;
         }
 
         return $this->exec($api);
@@ -701,100 +701,101 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'https://music.163.com/api/song/enhance/player/url',
-                'body'   => array(
-                    'ids' => array($id),
-                    'br'  => $br * 999999,
-                ),
-                'encode' => 'netease_AESCBC',
-                'decode' => 'netease_url',
-            );
-            break;
-            case 'tencent':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_play_single_song.fcg',
-                'body'   => array(
-                    'songmid'  => $id,
-                    'platform' => 'yqq',
-                    'format'   => 'json',
-                ),
-                'decode' => 'tencent_url',
-            );
-            break;
-            case 'xiami':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.songservice.getsongs/1.0/',
-                'body'   => array(
-                    'data' => array(
-                        'songIds' => array(
-                            $id,
-                        ),
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://music.163.com/api/song/enhance/player/url',
+                    'body'   => array(
+                        'ids' => array($id),
+                        'br'  => $br * 999999,
                     ),
-                    'r' => 'mtop.alimusic.music.songservice.getsongs',
-                ),
-                'encode' => 'xiami_sign',
-                'decode' => 'xiami_url',
-            );
-            break;
+                    'encode' => 'netease_AESCBC',
+                    'decode' => 'netease_url',
+                );
+                break;
+            case 'tencent':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_play_single_song.fcg',
+                    'body'   => array(
+                        'songmid'  => $id,
+                        'platform' => 'yqq',
+                        'format'   => 'json',
+                    ),
+                    'decode' => 'tencent_url',
+                );
+                break;
+            case 'xiami':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://acs.m.xiami.com/h5/mtop.alimusic.music.songservice.getsongs/1.0/',
+                    'body'   => array(
+                        'data' => array(
+                            'songIds' => array(
+                                $id,
+                            ),
+                        ),
+                        'r' => 'mtop.alimusic.music.songservice.getsongs',
+                    ),
+                    'encode' => 'xiami_sign',
+                    'decode' => 'xiami_url',
+                );
+                break;
             case 'kugou':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'http://media.store.kugou.com/v1/get_res_privilege',
-                'body'   => json_encode(
-                    array(
-                    'relate'    => 1,
-                    'userid'    => '0',
-                    'vip'       => 0,
-                    'appid'     => 1000,
-                    'token'     => '',
-                    'behavior'  => 'download',
-                    'area_code' => '1',
-                    'clientver' => '8990',
-                    'resource'  => array(array(
-                        'id'   => 0,
-                        'type' => 'audio',
-                        'hash' => $id,
-                    )), )
-                ),
-                'decode' => 'kugou_url',
-            );
-            break;
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'http://media.store.kugou.com/v1/get_res_privilege',
+                    'body'   => json_encode(
+                        array(
+                            'relate'    => 1,
+                            'userid'    => '0',
+                            'vip'       => 0,
+                            'appid'     => 1000,
+                            'token'     => '',
+                            'behavior'  => 'download',
+                            'area_code' => '1',
+                            'clientver' => '8990',
+                            'resource'  => array(array(
+                                'id'   => 0,
+                                'type' => 'audio',
+                                'hash' => $id,
+                            )),
+                        )
+                    ),
+                    'decode' => 'kugou_url',
+                );
+                break;
             case 'baidu':
-            $api = array(
-                'method' => 'GET',
-                'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
-                'body'   => array(
-                    'from'     => 'qianqianmini',
-                    'method'   => 'baidu.ting.song.getInfos',
-                    'songid'   => $id,
-                    'res'      => 1,
-                    'platform' => 'darwin',
-                    'version'  => '1.0.0',
-                ),
-                'encode' => 'baidu_AESCBC',
-                'decode' => 'baidu_url',
-            );
-            break;
-			case 'kuwo':
-			$api = array(
-				'method' => 'GET',
-				'url'    => 'http://www.kuwo.cn/url',
-				'body'   => array(
-					'rid'         => $id,
-					'response'    => 'url',
-					'type'        => 'convert_url3',
-					'br'          => '128kmp3',
-					'from'        => 'web',
-					't'           => time(),
-					'httpsStatus' => 1,
-				),
-				'decode' => 'kuwo_url',
-			);
-			break;
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'body'   => array(
+                        'from'     => 'qianqianmini',
+                        'method'   => 'baidu.ting.song.getInfos',
+                        'songid'   => $id,
+                        'res'      => 1,
+                        'platform' => 'darwin',
+                        'version'  => '1.0.0',
+                    ),
+                    'encode' => 'baidu_AESCBC',
+                    'decode' => 'baidu_url',
+                );
+                break;
+            case 'kuwo':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'http://www.kuwo.cn/url',
+                    'body'   => array(
+                        'rid'         => $id,
+                        'response'    => 'url',
+                        'type'        => 'convert_url3',
+                        'br'          => '128kmp3',
+                        'from'        => 'web',
+                        't'           => time(),
+                        'httpsStatus' => 1,
+                    ),
+                    'decode' => 'kuwo_url',
+                );
+                break;
         }
         $this->temp['br'] = $br;
 
@@ -805,43 +806,42 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $api = array(
-                'method' => 'POST',
-                'url'    => 'https://music.163.com/api/song/lyric',
-                'body'   => array(
-                    'id'        => $id,
-                    'os'        => 'pc',
-                    'lv'        => -1,
-                    'kv'        => -1,
-                    'tv'        => -1,
-                    'rv'        => -1,
-                    'yv'        => 1,
-                    'showRole'  => 'False',
-                    'cp'        => 'False',
-                    'e_r'       => 'False',
-                ),
-                'encode' => 'netease_AESCBC',
-            );
-            // 发送请求，获取结果
-            $result = $this->exec($api);
-            $tmp = json_decode($result, true);
-            // 手动处理返回结果
-            if (isset($tmp['yrc'])) {
-                // 如果存在 yrc 字段，进一步判断 yrc 参数的值
-                if ($this->yrc) {
-                    // yrc 参数为 true，手动处理 netease_lyric_yrc 解析
-                    $decoded_result = $this->netease_lyric_yrc($result);
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://music.163.com/api/song/lyric',
+                    'body'   => array(
+                        'id'        => $id,
+                        'os'        => 'pc',
+                        'lv'        => -1,
+                        'kv'        => -1,
+                        'tv'        => -1,
+                        'rv'        => -1,
+                        'yv'        => 1,
+                        'showRole'  => 'False',
+                        'cp'        => 'False',
+                        'e_r'       => 'False',
+                    ),
+                    'encode' => 'netease_AESCBC',
+                );
+                // 发送请求，获取结果
+                $result = $this->exec($api);
+                $tmp = json_decode($result, true);
+                // 手动处理返回结果
+                if (isset($tmp['yrc'])) {
+                    // 如果存在 yrc 字段，进一步判断 yrc 参数的值
+                    if ($this->yrc) {
+                        // yrc 参数为 true，手动处理 netease_lyric_yrc 解析
+                        $decoded_result = $this->netease_lyric_yrc($result);
+                    } else {
+                        // yrc 参数为 false，手动处理普通 netease_lyric 解析
+                        $decoded_result = $this->netease_lyric($result);
+                    }
                 } else {
-                    // yrc 参数为 false，手动处理普通 netease_lyric 解析
+                    // 不存在 yrc 字段，直接执行普通 netease_lyric 解析
                     $decoded_result = $this->netease_lyric($result);
                 }
-            } else {
-                // 不存在 yrc 字段，直接执行普通 netease_lyric 解析
-                $decoded_result = $this->netease_lyric($result);
-            }
-            // 返回最终处理后的结果
-            return $decoded_result;
-            break;
+                // 返回最终处理后的结果
+                return $decoded_result;
 
             case 'tencent':
                 $api = array(
@@ -920,41 +920,41 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            $url = 'https://p3.music.126.net/'.$this->netease_encryptId($id).'/'.$id.'.jpg?param=';
-            break;
+                $url = 'https://p3.music.126.net/' . $this->netease_encryptId($id) . '/' . $id . '.jpg?param=';
+                break;
             case 'tencent':
-            $url = 'https://y.gtimg.cn/music/photo_new/T002R'.$size.'x'.$size.'M000'.$id.'.jpg?max_age=2592000';
-            break;
+                $url = 'https://y.gtimg.cn/music/photo_new/T002R' . $size . 'x' . $size . 'M000' . $id . '.jpg?max_age=2592000';
+                break;
             case 'xiami':
-            $format = $this->format;
-            $data = $this->format(false)->song($id);
-            $this->format = $format;
-            $data = json_decode($data, true);
-            $url = $data['data']['data']['songDetail']['albumLogo'];
-            $url = str_replace('http:', 'https:', $url).'@1e_1c_100Q_'.$size.'h_'.$size.'w';
-            break;
+                $format = $this->format;
+                $data = $this->format(false)->song($id);
+                $this->format = $format;
+                $data = json_decode($data, true);
+                $url = $data['data']['data']['songDetail']['albumLogo'];
+                $url = str_replace('http:', 'https:', $url) . '@1e_1c_100Q_' . $size . 'h_' . $size . 'w';
+                break;
             case 'kugou':
-            $format = $this->format;
-            $data = $this->format(false)->song($id);
-            $this->format = $format;
-            $data = json_decode($data, true);
-            $url = $data['imgUrl'];
-            $url = str_replace('{size}', '400', $url);
-            break;
+                $format = $this->format;
+                $data = $this->format(false)->song($id);
+                $this->format = $format;
+                $data = json_decode($data, true);
+                $url = $data['imgUrl'];
+                $url = str_replace('{size}', '400', $url);
+                break;
             case 'baidu':
-            $format = $this->format;
-            $data = $this->format(false)->song($id);
-            $this->format = $format;
-            $data = json_decode($data, true);
-            $url = isset($data['songinfo']['pic_radio']) ? $data['songinfo']['pic_radio'] : $data['songinfo']['pic_small'];
-            break;
-			case 'kuwo':
-			$format = $this->format;
-            $data = $this->format(false)->song($id);
-            $this->format = $format;
-            $data = json_decode($data, true);
-			$url = isset($data['data']['pic']) ? $data['data']['pic'] : $data['data']['albumpic'];
-			break;
+                $format = $this->format;
+                $data = $this->format(false)->song($id);
+                $this->format = $format;
+                $data = json_decode($data, true);
+                $url = isset($data['songinfo']['pic_radio']) ? $data['songinfo']['pic_radio'] : $data['songinfo']['pic_small'];
+                break;
+            case 'kuwo':
+                $format = $this->format;
+                $data = $this->format(false)->song($id);
+                $this->format = $format;
+                $data = json_decode($data, true);
+                $url = isset($data['data']['pic']) ? $data['data']['pic'] : $data['data']['albumpic'];
+                break;
         }
 
         return json_encode(array('url' => $url));
@@ -964,55 +964,55 @@ class Meting
     {
         switch ($this->server) {
             case 'netease':
-            return array(
-                'Referer'         => 'https://music.163.com/',
-                'Cookie'          => 'appver=8.2.30; os=iPhone OS; osver=15.0; EVNSM=1.0.0; buildver=2206; channel=distribution; machineid=iPhone13.3',
-                'User-Agent'      => 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 CloudMusic/0.1.1 NeteaseMusic/8.2.30',
-                'X-Real-IP'       => long2ip(mt_rand(1884815360, 1884890111)),
-                'Accept'          => '*/*',
-                'Accept-Language' => 'zh-CN,zh;q=0.8,gl;q=0.6,zh-TW;q=0.4',
-                'Connection'      => 'keep-alive',
-                'Content-Type'    => 'application/x-www-form-urlencoded',
-            );
+                return array(
+                    'Referer'         => 'https://music.163.com/',
+                    'Cookie'          => 'appver=8.2.30; os=iPhone OS; osver=15.0; EVNSM=1.0.0; buildver=2206; channel=distribution; machineid=iPhone13.3',
+                    'User-Agent'      => 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 CloudMusic/0.1.1 NeteaseMusic/8.2.30',
+                    'X-Real-IP'       => long2ip(mt_rand(1884815360, 1884890111)),
+                    'Accept'          => '*/*',
+                    'Accept-Language' => 'zh-CN,zh;q=0.8,gl;q=0.6,zh-TW;q=0.4',
+                    'Connection'      => 'keep-alive',
+                    'Content-Type'    => 'application/x-www-form-urlencoded',
+                );
             case 'tencent':
-            return array(
-                'Referer'         => 'http://y.qq.com',
-                'Cookie'          => 'pgv_pvi=22038528; pgv_si=s3156287488; pgv_pvid=5535248600; yplayer_open=1; ts_last=y.qq.com/portal/player.html; ts_uid=4847550686; yq_index=0; qqmusic_fromtag=66; player_exist=1',
-                'User-Agent'      => 'QQ%E9%9F%B3%E4%B9%90/54409 CFNetwork/901.1 Darwin/17.6.0 (x86_64)',
-                'Accept'          => '*/*',
-                'Accept-Language' => 'zh-CN,zh;q=0.8,gl;q=0.6,zh-TW;q=0.4',
-                'Connection'      => 'keep-alive',
-                'Content-Type'    => 'application/x-www-form-urlencoded',
-            );
+                return array(
+                    'Referer'         => 'http://y.qq.com',
+                    'Cookie'          => 'pgv_pvi=22038528; pgv_si=s3156287488; pgv_pvid=5535248600; yplayer_open=1; ts_last=y.qq.com/portal/player.html; ts_uid=4847550686; yq_index=0; qqmusic_fromtag=66; player_exist=1',
+                    'User-Agent'      => 'QQ%E9%9F%B3%E4%B9%90/54409 CFNetwork/901.1 Darwin/17.6.0 (x86_64)',
+                    'Accept'          => '*/*',
+                    'Accept-Language' => 'zh-CN,zh;q=0.8,gl;q=0.6,zh-TW;q=0.4',
+                    'Connection'      => 'keep-alive',
+                    'Content-Type'    => 'application/x-www-form-urlencoded',
+                );
             case 'xiami':
-            return array(
-                'Cookie'          => '_m_h5_tk=15d3402511a022796d88b249f83fb968_1511163656929; _m_h5_tk_enc=b6b3e64d81dae577fc314b5c5692df3c',
-                'User-Agent'      => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/537.36 (KHTML, like Gecko) XIAMI-MUSIC/3.1.1 Chrome/56.0.2924.87 Electron/1.6.11 Safari/537.36',
-                'Accept'          => 'application/json',
-                'Content-type'    => 'application/x-www-form-urlencoded',
-                'Accept-Language' => 'zh-CN',
-            );
+                return array(
+                    'Cookie'          => '_m_h5_tk=15d3402511a022796d88b249f83fb968_1511163656929; _m_h5_tk_enc=b6b3e64d81dae577fc314b5c5692df3c',
+                    'User-Agent'      => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_5) AppleWebKit/537.36 (KHTML, like Gecko) XIAMI-MUSIC/3.1.1 Chrome/56.0.2924.87 Electron/1.6.11 Safari/537.36',
+                    'Accept'          => 'application/json',
+                    'Content-type'    => 'application/x-www-form-urlencoded',
+                    'Accept-Language' => 'zh-CN',
+                );
             case 'kugou':
-            return array(
-                'User-Agent'      => 'IPhone-8990-searchSong',
-                'UNI-UserAgent'   => 'iOS11.4-Phone8990-1009-0-WiFi',
-            );
+                return array(
+                    'User-Agent'      => 'IPhone-8990-searchSong',
+                    'UNI-UserAgent'   => 'iOS11.4-Phone8990-1009-0-WiFi',
+                );
             case 'baidu':
-            return array(
-                'Cookie'          => 'BAIDUID='.$this->getRandomHex(32).':FG=1',
-                'User-Agent'      => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) baidu-music/1.2.1 Chrome/66.0.3359.181 Electron/3.0.5 Safari/537.36',
-                'Accept'          => '*/*',
-                'Content-type'    => 'application/json;charset=UTF-8',
-                'Accept-Language' => 'zh-CN',
-            );
-			case 'kuwo':
-            return array(
-				'Cookie'		  => 'Hm_lvt_cdb524f42f0ce19b169a8071123a4797=1623339177,1623339183; _ga=GA1.2.1195980605.1579367081; Hm_lpvt_cdb524f42f0ce19b169a8071123a4797=1623339982; kw_token=3E7JFQ7MRPL; _gid=GA1.2.747985028.1623339179; _gat=1',
-                'csrf'            => '3E7JFQ7MRPL',
-				'Host'            => 'www.kuwo.cn',
-				'Referer'         => 'http://www.kuwo.cn/',
-				'User-Agent'      => 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36',
-            );
+                return array(
+                    'Cookie'          => 'BAIDUID=' . $this->getRandomHex(32) . ':FG=1',
+                    'User-Agent'      => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) baidu-music/1.2.1 Chrome/66.0.3359.181 Electron/3.0.5 Safari/537.36',
+                    'Accept'          => '*/*',
+                    'Content-type'    => 'application/json;charset=UTF-8',
+                    'Accept-Language' => 'zh-CN',
+                );
+            case 'kuwo':
+                return array(
+                    'Cookie'          => 'Hm_lvt_cdb524f42f0ce19b169a8071123a4797=1623339177,1623339183; _ga=GA1.2.1195980605.1579367081; Hm_lpvt_cdb524f42f0ce19b169a8071123a4797=1623339982; kw_token=3E7JFQ7MRPL; _gid=GA1.2.747985028.1623339179; _gat=1',
+                    'csrf'            => '3E7JFQ7MRPL',
+                    'Host'            => 'www.kuwo.cn',
+                    'Referer'         => 'http://www.kuwo.cn/',
+                    'User-Agent'      => 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36',
+                );
         }
     }
 
@@ -1020,9 +1020,6 @@ class Meting
     {
         if (function_exists('random_bytes')) {
             return bin2hex(random_bytes($length / 2));
-        }
-        if (function_exists('mcrypt_create_iv')) {
-            return bin2hex(mcrypt_create_iv($length / 2, MCRYPT_DEV_URANDOM));
         }
         if (function_exists('openssl_random_pseudo_bytes')) {
             return bin2hex(openssl_random_pseudo_bytes($length / 2));
@@ -1045,7 +1042,7 @@ class Meting
         $hex = '';
         do {
             $last = bcmod($dec, 16);
-            $hex = dechex($last).$hex;
+            $hex = dechex($last) . $hex;
             $dec = bcdiv(bcsub($dec, $last), 16);
         } while ($dec > 0);
 
@@ -1058,7 +1055,7 @@ class Meting
         for ($i = 0; $i < strlen($string); $i++) {
             $ord = ord($string[$i]);
             $hexCode = dechex($ord);
-            $hex .= substr('0'.$hexCode, -2);
+            $hex .= substr('0' . $hexCode, -2);
         }
 
         return $hex;
@@ -1080,14 +1077,18 @@ class Meting
         $body = json_encode($api['body']);
 
         if (function_exists('openssl_encrypt')) {
-            $body = openssl_encrypt($body, 'aes-128-cbc', $nonce, false, $vi);
-            $body = openssl_encrypt($body, 'aes-128-cbc', $skey, false, $vi);
-        } else {
+            // 使用 openssl_encrypt 进行加密
             $pad = 16 - (strlen($body) % 16);
-            $body = base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $nonce, $body.str_repeat(chr($pad), $pad), MCRYPT_MODE_CBC, $vi));
+            $body = $body . str_repeat(chr($pad), $pad);
+            $body = openssl_encrypt($body, 'aes-128-cbc', $nonce, OPENSSL_RAW_DATA, $vi);
+            $body = base64_encode($body);
+
             $pad = 16 - (strlen($body) % 16);
-            $body = base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $skey, $body.str_repeat(chr($pad), $pad), MCRYPT_MODE_CBC, $vi));
+            $body = $body . str_repeat(chr($pad), $pad);
+            $body = openssl_encrypt($body, 'aes-128-cbc', $skey, OPENSSL_RAW_DATA, $vi);
+            $body = base64_encode($body);
         }
+
 
         if (extension_loaded('bcmath')) {
             $skey = strrev(mb_convert_encoding($skey, 'UTF-8', 'ISO-8859-1'));
@@ -1113,14 +1114,16 @@ class Meting
         $key = 'DBEECF8C50FD160E';
         $vi = '1231021386755796';
 
-        $data = 'songid='.$api['body']['songid'].'&ts='.intval(microtime(true) * 1000);
+        $data = 'songid=' . $api['body']['songid'] . '&ts=' . intval(microtime(true) * 1000);
 
         if (function_exists('openssl_encrypt')) {
-            $data = openssl_encrypt($data, 'aes-128-cbc', $key, false, $vi);
-        } else {
+            // 为了确保数据长度是 16 的倍数，先进行填充
             $pad = 16 - (strlen($data) % 16);
-            $data = base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $key, $data.str_repeat(chr($pad), $pad), MCRYPT_MODE_CBC, $vi));
+            $data = $data . str_repeat(chr($pad), $pad);  // 填充
+            $data = openssl_encrypt($data, 'aes-128-cbc', $key, OPENSSL_RAW_DATA, $vi);
+            $data = base64_encode($data);  // 加密后进行 base64 编码
         }
+
 
         $api['body']['e'] = $data;
 
@@ -1131,7 +1134,7 @@ class Meting
     {
         $data = $this->curl('https://acs.m.xiami.com/h5/mtop.alimusic.recommend.songservice.getdailysongs/1.0/?appKey=12574478&t=1560663823000&dataType=json&data=%7B%22requestStr%22%3A%22%7B%5C%22header%5C%22%3A%7B%5C%22platformId%5C%22%3A%5C%22mac%5C%22%7D%2C%5C%22model%5C%22%3A%5B%5D%7D%22%7D&api=mtop.alimusic.recommend.songservice.getdailysongs&v=1.0&type=originaljson&sign=22ad1377ee193f3e2772c17c6192b17c', null, 1);
         preg_match_all('/_m_h5[^;]+/', $data->raw, $match);
-        $this->header['Cookie'] = $match[0][0].'; '.$match[0][1];
+        $this->header['Cookie'] = $match[0][0] . '; ' . $match[0][1];
         $data = json_encode(array(
             'requestStr' => json_encode(array(
                 'header' => array(
@@ -1235,7 +1238,7 @@ class Meting
 
         foreach ($type as $vo) {
             $payload['req_0']['param']['songmid'][] = $data['data'][0]['mid'];
-            $payload['req_0']['param']['filename'][] = $vo[2].$data['data'][0]['file']['media_mid'].'.'.$vo[3];
+            $payload['req_0']['param']['filename'][] = $vo[2] . $data['data'][0]['file']['media_mid'] . '.' . $vo[3];
             $payload['req_0']['param']['songtype'][] = $data['data'][0]['type'];
         }
 
@@ -1256,7 +1259,7 @@ class Meting
             if ($data['data'][0]['file'][$vo[0]] && $vo[1] <= $this->temp['br']) {
                 if (!empty($vkeys[$index]['vkey'])) {
                     $url = array(
-                        'url'  => $response['req_0']['data']['sip'][0].$vkeys[$index]['purl'],
+                        'url'  => $response['req_0']['data']['sip'][0] . $vkeys[$index]['purl'],
                         'size' => $data['data'][0]['file'][$vo[0]],
                         'br'   => $vo[1],
                     );
@@ -1322,7 +1325,7 @@ class Meting
                     'url'    => 'http://trackercdn.kugou.com/i/v2/',
                     'body'   => array(
                         'hash'     => $vo['hash'],
-                        'key'      => md5($vo['hash'].'kgcloudv2'),
+                        'key'      => md5($vo['hash'] . 'kgcloudv2'),
                         'pid'      => 3,
                         'behavior' => 'play',
                         'cmd'      => '25',
@@ -1375,7 +1378,7 @@ class Meting
         return json_encode($url);
     }
 
-	private function kuwo_url($result)
+    private function kuwo_url($result)
     {
         $data = json_decode($result, true);
 
@@ -1447,8 +1450,8 @@ class Meting
             preg_match_all('/\[([\d:\.]+)\](.*)\s\[x-trans\](.*)/i', $data, $match);
             if (count($match[0])) {
                 for ($i = 0; $i < count($match[0]); $i++) {
-                    $A[] = '['.$match[1][$i].']'.$match[2][$i];
-                    $B[] = '['.$match[1][$i].']'.$match[3][$i];
+                    $A[] = '[' . $match[1][$i] . ']' . $match[2][$i];
+                    $B[] = '[' . $match[1][$i] . ']' . $match[3][$i];
                 }
                 $arr = array(
                     'lyric'  => str_replace($match[0], $A, $data),
@@ -1505,30 +1508,30 @@ class Meting
         return json_encode($data, JSON_UNESCAPED_UNICODE);
     }
 
-	private function kuwo_lyric($result)
+    private function kuwo_lyric($result)
     {
         $result = json_decode($result, true);
         if (count($result['data']['lrclist'])) {
-			$kuwolrc = '';
-			for ($i = 0; $i < count($result['data']['lrclist']); $i++) {
-				$otime = $result['data']['lrclist'][$i]['time'];
-				$osec = explode('.', $otime)[0];
-				$min = str_pad(floor($osec / 60), 2, "0", STR_PAD_LEFT);
-				$sec = str_pad($osec - $min * 60, 2, "0", STR_PAD_LEFT);
-				$msec = explode('.', $otime)[1];
-				$olyric = $result['data']['lrclist'][$i]['lineLyric'];
-				$kuwolrc = $kuwolrc . '[' . $min . ':' . $sec . '.' . $msec . ']' . $olyric . "\n";
-			}
-			$arr = array(
-				'lyric'  => $kuwolrc,
-				'tlyric' => '',
-			);
+            $kuwolrc = '';
+            for ($i = 0; $i < count($result['data']['lrclist']); $i++) {
+                $otime = $result['data']['lrclist'][$i]['time'];
+                $osec = explode('.', $otime)[0];
+                $min = str_pad(floor($osec / 60), 2, "0", STR_PAD_LEFT);
+                $sec = str_pad($osec - $min * 60, 2, "0", STR_PAD_LEFT);
+                $msec = explode('.', $otime)[1];
+                $olyric = $result['data']['lrclist'][$i]['lineLyric'];
+                $kuwolrc = $kuwolrc . '[' . $min . ':' . $sec . '.' . $msec . ']' . $olyric . "\n";
+            }
+            $arr = array(
+                'lyric'  => $kuwolrc,
+                'tlyric' => '',
+            );
         } else {
-			$arr = array(
+            $arr = array(
                 'lyric'  => '',
                 'tlyric' => '',
             );
-		}
+        }
         return json_encode($arr, JSON_UNESCAPED_UNICODE);
     }
 
@@ -1608,11 +1611,31 @@ class Meting
             'lyric_id' => $data['hash'],
             'source'   => 'kugou',
         );
-        list($result['artist'], $result['name']) = explode(' - ', $result['name'], 2);
-        $result['artist'] = explode('、', $result['artist']);
+
+        // 确保 'name' 是字符串类型并包含 ' - '
+        if (is_string($result['name']) && strpos($result['name'], ' - ') !== false) {
+            list($result['artist'], $result['name']) = explode(' - ', $result['name'], 2);
+        } else {
+            // 如果 'name' 中没有 ' - '，将 artist 设置为默认空数组
+            $result['artist'] = [];
+        }
+
+        // 如果 'artist' 是数组类型，不应该传递给 explode 函数
+        if (is_array($result['artist'])) {
+            // 如果 'artist' 已经是数组，跳过 explode 操作
+            $result['artist'] = implode('、', $result['artist']);
+        }
+
+        // 只有当 artist 是字符串时才使用 explode
+        if (is_string($result['artist'])) {
+            $result['artist'] = explode('、', $result['artist']);
+        }
 
         return $result;
     }
+
+
+
 
     protected function format_baidu($data)
     {
@@ -1630,7 +1653,7 @@ class Meting
         return $result;
     }
 
-	protected function format_kuwo($data)
+    protected function format_kuwo($data)
     {
         $result = array(
             'id'       => $data['rid'],
@@ -1645,5 +1668,4 @@ class Meting
 
         return $result;
     }
-
 }

--- a/src/Meting.php
+++ b/src/Meting.php
@@ -219,7 +219,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://mobilecdn.kugou.com/api/v3/search/song',
+                    'url'    => 'https://mobilecdn.kugou.com/api/v3/search/song',
                     'body'   => array(
                         'api_ver'   => 1,
                         'area_code' => 1,
@@ -239,7 +239,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'      => 'qianqianmini',
                         'method'    => 'baidu.ting.search.merge',
@@ -256,7 +256,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://www.kuwo.cn/api/www/search/searchMusicBykeyWord',
+                    'url'    => 'https://www.kuwo.cn/api/www/search/searchMusicBykeyWord',
                     'body'   => array(
                         'key'         => $keyword,
                         'pn'          => isset($option['page']) ? $option['page'] : 1,
@@ -314,7 +314,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'POST',
-                    'url'    => 'http://m.kugou.com/app/i/getSongInfo.php',
+                    'url'    => 'https://m.kugou.com/app/i/getSongInfo.php',
                     'body'   => array(
                         'cmd'  => 'playInfo',
                         'hash' => $id,
@@ -326,7 +326,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'     => 'qianqianmini',
                         'method'   => 'baidu.ting.song.getInfos',
@@ -342,7 +342,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://www.kuwo.cn/api/www/music/musicInfo',
+                    'url'    => 'https://www.kuwo.cn/api/www/music/musicInfo',
                     'body'   => array(
                         'mid'         => $id,
                         'httpsStatus' => 1,
@@ -404,7 +404,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://mobilecdn.kugou.com/api/v3/album/song',
+                    'url'    => 'https://mobilecdn.kugou.com/api/v3/album/song',
                     'body'   => array(
                         'albumid'   => $id,
                         'area_code' => 1,
@@ -419,7 +419,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'     => 'qianqianmini',
                         'method'   => 'baidu.ting.album.getAlbumInfo',
@@ -433,7 +433,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://www.kuwo.cn/api/www/album/albumInfo',
+                    'url'    => 'https://www.kuwo.cn/api/www/album/albumInfo',
                     'body'   => array(
                         'albumId'     => $id,
                         'pn'          => 1,
@@ -501,7 +501,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://mobilecdn.kugou.com/api/v3/singer/song',
+                    'url'    => 'https://mobilecdn.kugou.com/api/v3/singer/song',
                     'body'   => array(
                         'singerid'  => $id,
                         'area_code' => 1,
@@ -516,7 +516,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'     => 'qianqianmini',
                         'method'   => 'baidu.ting.artist.getSongList',
@@ -533,7 +533,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://www.kuwo.cn/api/www/artist/artistMusic',
+                    'url'    => 'https://www.kuwo.cn/api/www/artist/artistMusic',
                     'body'   => array(
                         'artistid'    => $id,
                         'pn'          => 1,
@@ -653,7 +653,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://mobilecdn.kugou.com/api/v3/special/song',
+                    'url'    => 'https://mobilecdn.kugou.com/api/v3/special/song',
                     'body'   => array(
                         'specialid' => $id,
                         'area_code' => 1,
@@ -668,7 +668,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'     => 'qianqianmini',
                         'method'   => 'baidu.ting.diy.gedanInfo',
@@ -682,7 +682,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://www.kuwo.cn/api/www/playlist/playListInfo',
+                    'url'    => 'https://www.kuwo.cn/api/www/playlist/playListInfo',
                     'body'   => array(
                         'pid'         => $id,
                         'pn'          => 1,
@@ -743,7 +743,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'POST',
-                    'url'    => 'http://media.store.kugou.com/v1/get_res_privilege',
+                    'url'    => 'https://media.store.kugou.com/v1/get_res_privilege',
                     'body'   => json_encode(
                         array(
                             'relate'    => 1,
@@ -767,7 +767,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'     => 'qianqianmini',
                         'method'   => 'baidu.ting.song.getInfos',
@@ -783,7 +783,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://www.kuwo.cn/url',
+                    'url'    => 'https://www.kuwo.cn/url',
                     'body'   => array(
                         'rid'         => $id,
                         'response'    => 'url',
@@ -873,7 +873,7 @@ class Meting
             case 'kugou':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://krcs.kugou.com/search',
+                    'url'    => 'https://krcs.kugou.com/search',
                     'body'   => array(
                         'keyword'  => '%20-%20',
                         'ver'      => 1,
@@ -888,7 +888,7 @@ class Meting
             case 'baidu':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://musicapi.taihe.com/v1/restserver/ting',
+                    'url'    => 'https://musicapi.taihe.com/v1/restserver/ting',
                     'body'   => array(
                         'from'     => 'qianqianmini',
                         'method'   => 'baidu.ting.song.lry',
@@ -903,7 +903,7 @@ class Meting
             case 'kuwo':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://m.kuwo.cn/newh5/singles/songinfoandlrc',
+                    'url'    => 'https://m.kuwo.cn/newh5/singles/songinfoandlrc',
                     'body'   => array(
                         'musicId'     => $id,
                         'httpsStatus' => 1,
@@ -976,7 +976,7 @@ class Meting
                 );
             case 'tencent':
                 return array(
-                    'Referer'         => 'http://y.qq.com',
+                    'Referer'         => 'https://y.qq.com',
                     'Cookie'          => 'pgv_pvi=22038528; pgv_si=s3156287488; pgv_pvid=5535248600; yplayer_open=1; ts_last=y.qq.com/portal/player.html; ts_uid=4847550686; yq_index=0; qqmusic_fromtag=66; player_exist=1',
                     'User-Agent'      => 'QQ%E9%9F%B3%E4%B9%90/54409 CFNetwork/901.1 Darwin/17.6.0 (x86_64)',
                     'Accept'          => '*/*',
@@ -1010,7 +1010,7 @@ class Meting
                     'Cookie'          => 'Hm_lvt_cdb524f42f0ce19b169a8071123a4797=1623339177,1623339183; _ga=GA1.2.1195980605.1579367081; Hm_lpvt_cdb524f42f0ce19b169a8071123a4797=1623339982; kw_token=3E7JFQ7MRPL; _gid=GA1.2.747985028.1623339179; _gat=1',
                     'csrf'            => '3E7JFQ7MRPL',
                     'Host'            => 'www.kuwo.cn',
-                    'Referer'         => 'http://www.kuwo.cn/',
+                    'Referer'         => 'https://www.kuwo.cn/',
                     'User-Agent'      => 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.77 Safari/537.36',
                 );
         }
@@ -1322,7 +1322,7 @@ class Meting
             if ($vo['info']['bitrate'] <= $this->temp['br'] && $vo['info']['bitrate'] > $max) {
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'http://trackercdn.kugou.com/i/v2/',
+                    'url'    => 'https://trackercdn.kugou.com/i/v2/',
                     'body'   => array(
                         'hash'     => $vo['hash'],
                         'key'      => md5($vo['hash'] . 'kgcloudv2'),
@@ -1478,7 +1478,7 @@ class Meting
         $result = json_decode($result, true);
         $api = array(
             'method' => 'GET',
-            'url'    => 'http://lyrics.kugou.com/download',
+            'url'    => 'https://lyrics.kugou.com/download',
             'body'   => array(
                 'charset'   => 'utf8',
                 'accesskey' => $result['candidates'][0]['accesskey'],

--- a/src/Meting.php
+++ b/src/Meting.php
@@ -697,7 +697,7 @@ class Meting
         return $this->exec($api);
     }
 
-    public function url($id, $br = 320)
+    public function url($id, $br = 2147483)
     {
         switch ($this->server) {
             case 'netease':
@@ -706,7 +706,7 @@ class Meting
                     'url'    => 'https://music.163.com/api/song/enhance/player/url',
                     'body'   => array(
                         'ids' => array($id),
-                        'br'  => $br * 999999,
+                        'br'  => $br * 1000,
                     ),
                     'encode' => 'netease_AESCBC',
                     'decode' => 'netease_url',
@@ -916,16 +916,27 @@ class Meting
         return $this->exec($api);
     }
 
-    public function pic($id, $size = 300)
+    public function pic($id, $size)
     {
         switch ($this->server) {
             case 'netease':
-                $url = 'https://p3.music.126.net/' . $this->netease_encryptId($id) . '/' . $id . '.jpg?param=';
+                if (isset($size) && !empty($size)) {
+                    $url = 'https://p3.music.126.net/' . $this->netease_encryptId($id) . '/' . $id . '.jpg?param=' . $size . 'x' . $size;
+                } else {
+                    $url = 'https://p3.music.126.net/' . $this->netease_encryptId($id) . '/' . $id . '.jpg';
+                };
                 break;
             case 'tencent':
-                $url = 'https://y.gtimg.cn/music/photo_new/T002R' . $size . 'x' . $size . 'M000' . $id . '.jpg?max_age=2592000';
+                if (isset($size) && !empty($size)) {
+                    $url = 'https://y.gtimg.cn/music/photo_new/T002R' . $size . 'x' . $size . 'M000' . $id . '.jpg';
+                } else {
+                    $url = 'https://y.gtimg.cn/music/photo_new/T002M000' . $id . '.jpg';
+                };
                 break;
             case 'xiami':
+                if (!isset($size) || empty($size)) {
+                    $size = 300;
+                };
                 $format = $this->format;
                 $data = $this->format(false)->song($id);
                 $this->format = $format;
@@ -934,6 +945,9 @@ class Meting
                 $url = str_replace('http:', 'https:', $url) . '@1e_1c_100Q_' . $size . 'h_' . $size . 'w';
                 break;
             case 'kugou':
+                if (!isset($size) || empty($size)) {
+                    $size = 300;
+                };
                 $format = $this->format;
                 $data = $this->format(false)->song($id);
                 $this->format = $format;
@@ -942,6 +956,9 @@ class Meting
                 $url = str_replace('{size}', '400', $url);
                 break;
             case 'baidu':
+                if (!isset($size) || empty($size)) {
+                    $size = 300;
+                };
                 $format = $this->format;
                 $data = $this->format(false)->song($id);
                 $this->format = $format;
@@ -949,6 +966,9 @@ class Meting
                 $url = isset($data['songinfo']['pic_radio']) ? $data['songinfo']['pic_radio'] : $data['songinfo']['pic_small'];
                 break;
             case 'kuwo':
+                if (!isset($size) || empty($size)) {
+                    $size = 300;
+                };
                 $format = $this->format;
                 $data = $this->format(false)->song($id);
                 $this->format = $format;

--- a/src/Meting.php
+++ b/src/Meting.php
@@ -22,7 +22,7 @@ class Meting
 
     public $raw;
     public $data;
-    public $info;
+    public $info = false;
     public $error;
     public $status;
 
@@ -142,7 +142,8 @@ class Meting
                 break;
             }
         }
-        curl_close($curl);
+        /* delete before php 8.0 */
+        // curl_close($curl);
 
         return $this;
     }
@@ -183,6 +184,7 @@ class Meting
                     'url'    => 'https://music.163.com/api/cloudsearch/pc',
                     'body'   => array(
                         's'      => $keyword,
+                        /* TODO: 多功能搜索实现 */
                         'type'   => isset($option['type']) ? $option['type'] : 1,
                         'limit'  => isset($option['limit']) ? $option['limit'] : 50,
                         'total'  => 'true',
@@ -194,19 +196,27 @@ class Meting
                 break;
             case 'tencent':
                 $api = array(
-                    'method' => 'GET',
-                    'url'    => 'https://c.y.qq.com/soso/fcgi-bin/client_search_cp',
-                    'body'   => array(
-                        'format'   => 'json',
-                        'p'        => isset($option['page']) ? $option['page'] : 1,
-                        'n'        => isset($option['limit']) ? $option['limit'] : 50,
-                        'w'        => $keyword,
-                        'aggr'     => 1,
-                        'lossless' => 1,
-                        'cr'       => 1,
-                        'new_json' => 1,
-                    ),
-                    'format' => 'data.song.list',
+                    'method' => 'POST',
+                    'url'    => 'https://u.y.qq.com/cgi-bin/musicu.fcg',
+                    'body'   => json_encode(array(
+                        'comm' => array(
+                            'ct'   => '19',
+                            'cv'   => '1859',
+                            'uin'  => '0',
+                        ),
+                        'req' => array(
+                            'method' => 'DoSearchForQQMusicDesktop',
+                            'module' => 'music.search.SearchCgiService',
+                            'param'  => array(
+                                'grp'          => 1,
+                                'num_per_page' => isset($option['limit']) ? (int)$option['limit'] : 50,
+                                'page_num'     => isset($option['page']) ? (int)$option['page'] : 1,
+                                'query'        => $keyword,
+                                'search_type'  => 0,
+                            ),
+                        ),
+                    )),
+                    'format' => 'req.data.body.song.list',
                 );
                 break;
         }
@@ -230,15 +240,192 @@ class Meting
                 break;
             case 'tencent':
                 $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://u.y.qq.com/cgi-bin/musicu.fcg',
+                    'body'   => json_encode(array(
+                        'comm' => array(
+                            'ct' => '19',
+                            'cv' => '1873',
+                            'uin' => '0',
+                        ),
+                        'req_1' => array(
+                            'method' => 'get_song_detail_yqq',
+                            'module' => 'music.pf_song_detail_svr',
+                            'param' => array(
+                                'song_type' => 0,
+                                'song_mid' => $id,
+                                'song_id' => ''
+                            )
+                        )
+                    )),
+                    'format' => 'data',
+                );
+                break;
+        }
+
+        return $this->exec($api);
+    }
+
+    public function mv($id, $info = false)
+    {
+        switch ($this->server) {
+            case 'netease':
+                $api = array(
                     'method' => 'GET',
-                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_play_single_song.fcg',
+                    'url'    => 'https://music.163.com/api/mv/detail',
                     'body'   => array(
-                        'songmid'  => $id,
+                        'id'  => $id,
+                    ),
+                );
+                $raw_data = $this->exec($api);
+
+                if (!$raw_data) {
+                    return $raw_data;
+                }
+
+                $decoded_data = json_decode($raw_data, true);
+                if (!isset($decoded_data['code']) || $decoded_data['code'] !== 200 || !isset($decoded_data['data'])) {
+                    return $raw_data;
+                }
+
+                $mv_data = $decoded_data['data'];
+
+                if (empty($mv_data['brs'])) {
+                    return $info ? json_encode(array()) : null;
+                }
+
+                $brs = $mv_data['brs'];
+                krsort($brs, SORT_NUMERIC);
+                $best_url = reset($brs);
+
+                if (!$info) {
+                    return $best_url;
+                }
+
+                $result = array(
+                    'name'       => $mv_data['name'],
+                    'artistName' => $mv_data['artistName'],
+                    'cover'      => $mv_data['cover'],
+                    'url'        => $best_url,
+                );
+                return json_encode($result);
+
+            case 'tencent':
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://u.y.qq.com/cgi-bin/musicu.fcg',
+                    'body'   => json_encode(array(
+                        'comm' => array(
+                            'ct' => 6,
+                            'cv' => 0,
+                            'g_tk' => 1646675364,
+                            'uin' => 0,
+                            'format' => 'json',
+                            'platform' => 'yqq'
+                        ),
+                        'mvInfo' => array(
+                            'module' => 'music.video.VideoData',
+                            'method' => 'get_video_info_batch',
+                            'param' => array(
+                                'vidlist' => array($id),
+                                'required' => array('vid', 'type', 'sid', 'cover_pic', 'duration', 'singers', 'name', 'desc', 'playcnt', 'pubdate')
+                            )
+                        ),
+                        'mvUrl' => array(
+                            'module' => 'music.stream.MvUrlProxy',
+                            'method' => 'GetMvUrls',
+                            'param' => array(
+                                'vids' => array($id),
+                                'request_type' => 10003,
+                                'addrtype' => 3,
+                                'format' => 264,
+                                'maxFiletype' => 60
+                            )
+                        )
+                    )),
+                );
+                $raw_data = $this->exec($api);
+                if (!$raw_data) return $raw_data;
+                $decoded_data = json_decode($raw_data, true);
+
+                $mv_urls = $decoded_data['mvUrl']['data'][$id]['mp4'] ?? [];
+                if (empty($mv_urls)) return $info ? json_encode(array()) : null;
+
+                $best_url = '';
+                foreach (array_reverse($mv_urls) as $vo) {
+                    if (!empty($vo['freeflow_url']) && !empty($vo['freeflow_url'][0])) {
+                        $best_url = $vo['freeflow_url'][0];
+                        break;
+                    }
+                }
+                if (empty($best_url)) return $info ? json_encode(array()) : null;
+                if (!$info) return $best_url;
+
+                $mv_info = $decoded_data['mvInfo']['data'][$id] ?? [];
+                $artists = array();
+                if (isset($mv_info['singers'])) {
+                    foreach ($mv_info['singers'] as $s) {
+                        $artists[] = $s['name'];
+                    }
+                }
+                $result = array(
+                    'name'       => $mv_info['name'] ?? '',
+                    'artistName' => implode(', ', $artists),
+                    'cover'      => $mv_info['cover_pic'] ?? '',
+                    'url'        => $best_url,
+                );
+                return json_encode($result);
+        }
+        return null;
+    }
+
+    public function comment($id, $limit = 20, $offset = 0)
+    {
+        switch ($this->server) {
+            case 'netease':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://music.163.com/api/v1/resource/comments/R_SO_4_' . $id,
+                    'body'   => array(
+                        'limit'  => $limit,
+                        'offset' => $offset,
+                        'format' => 'json',
+                    ),
+                );
+                break;
+            case 'tencent':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://c.y.qq.com/base/fcgi-bin/fcg_global_comment_h5.fcg',
+                    'body'   => array(
+                        'cid'  => $id,
                         'platform' => 'yqq',
                         'format'   => 'json',
                     ),
-                    'format' => 'data',
+                    // 'format' => 'data',
                 );
+                break;
+        }
+
+        return $this->exec($api);
+    }
+
+    public function mvcomment($id, $limit = 20, $offset = 0)
+    {
+        switch ($this->server) {
+            case 'netease':
+                $api = array(
+                    'method' => 'GET',
+                    'url'    => 'https://music.163.com/api/v1/resource/comments/R_MV_5_' . $id,
+                    'body'   => array(
+                        'limit'  => $limit,
+                        'offset' => $offset,
+                        'format' => 'json',
+                    ),
+                );
+                break;
+            case 'tencent':
+                $api = array();
                 break;
         }
 
@@ -267,14 +454,19 @@ class Meting
             case 'tencent':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_album_detail_cp.fcg',
+                    'url'    => 'https://i.y.qq.com/v8/fcg-bin/fcg_v8_album_info_cp.fcg',
                     'body'   => array(
-                        'albummid' => $id,
-                        'platform' => 'mac',
-                        'format'   => 'json',
-                        'newsong'  => 1,
+                        'albummid'     => $id,
+                        'g_tk'         => 5381,
+                        'uin'          => 0,
+                        'format'       => 'json',
+                        'inCharset'    => 'utf-8',
+                        'outCharset'   => 'utf-8',
+                        'notice'       => 0,
+                        'platform'     => 'h5',
+                        'needNewCode'  => 1,
                     ),
-                    'format' => 'data.getSongInfo',
+                    'format' => 'data.list',
                 );
                 break;
         }
@@ -301,17 +493,25 @@ class Meting
                 break;
             case 'tencent':
                 $api = array(
-                    'method' => 'GET',
-                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_singer_track_cp.fcg',
-                    'body'   => array(
-                        'singermid' => $id,
-                        'begin'     => 0,
-                        'num'       => $limit,
-                        'order'     => 'listen',
-                        'platform'  => 'mac',
-                        'newsong'   => 1,
-                    ),
-                    'format' => 'data.list',
+                    'method' => 'POST',
+                    'url'    => 'https://u.y.qq.com/cgi-bin/musicu.fcg',
+                    'body'   => json_encode(array(
+                        'comm' => array(
+                            'ct'   => 24,
+                            'cv'   => 0,
+                        ),
+                        'req' => array(
+                            'module' => 'music.web_singer_info_svr',
+                            'method' => 'get_singer_detail_info',
+                            'param'  => array(
+                                'sort'      => 5,
+                                'singermid' => $id,
+                                'sin'       => 0,
+                                'num'       => (int)$limit,
+                            ),
+                        ),
+                    )),
+                    'format' => 'req.data.songlist',
                 );
                 break;
         }
@@ -336,6 +536,9 @@ class Meting
                     "encode" => "netease_AESCBC",
                 ];
                 $playlistData = json_decode($this->exec($api), true);
+                if (!isset($playlistData["playlist"]["trackIds"])) {
+                    return json_encode([]);
+                }
                 $trackIds = $playlistData["playlist"]["trackIds"];
                 $allTracks = [];
                 $idBatches = array_chunk(array_column($trackIds, "id"), 500);
@@ -367,10 +570,11 @@ class Meting
                         "id" => $data["id"],
                         "name" => $data["name"],
                         "artist" => [],
-                        "album" => $data["al"]["name"],
-                        "pic_id" => isset($data["al"]["pic_str"])
-                            ? $data["al"]["pic_str"]
-                            : $data["al"]["pic"],
+                        "album" => isset($data["al"]["name"]) ? $data["al"]["name"] : $data["album"],
+                        // "pic_id" => isset($data["al"]["pic_str"])
+                        //     ? $data["al"]["pic_str"]
+                        //     : $data["al"]["pic"],
+                        "pic_id" => $data["al"]["pic_str"] ?? $data["al"]["pic"] ?? $data["pic_id"],
                         "url_id" => $data["id"],
                         "lyric_id" => $data["id"],
                         "source" => "netease",
@@ -392,14 +596,25 @@ class Meting
             case 'tencent':
                 $api = array(
                     'method' => 'GET',
-                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_v8_playlist_cp.fcg',
+                    'url'    => 'https://i.y.qq.com/qzone-music/fcg-bin/fcg_ucc_getcdinfo_byids_cp.fcg',
                     'body'   => array(
-                        'id'       => $id,
-                        'format'   => 'json',
-                        'newsong'  => 1,
-                        'platform' => 'jqspaframe.json',
+                        'disstid'      => $id,
+                        'type'         => 1,
+                        'json'         => 1,
+                        'utf8'         => 1,
+                        'onlysong'     => 0,
+                        'nosign'       => 1,
+                        'g_tk'         => 5381,
+                        'loginUin'     => 0,
+                        'hostUin'      => 0,
+                        'format'       => 'json',
+                        'inCharset'    => 'GB2312',
+                        'outCharset'   => 'utf-8',
+                        'notice'       => 0,
+                        'platform'     => 'yqq',
+                        'needNewCode'  => 0,
                     ),
-                    'format' => 'data.cdlist.0.songlist',
+                    'format' => 'cdlist.0.songlist',
                 );
                 break;
         }
@@ -424,13 +639,24 @@ class Meting
                 break;
             case 'tencent':
                 $api = array(
-                    'method' => 'GET',
-                    'url'    => 'https://c.y.qq.com/v8/fcg-bin/fcg_play_single_song.fcg',
-                    'body'   => array(
-                        'songmid'  => $id,
-                        'platform' => 'yqq',
-                        'format'   => 'json',
-                    ),
+                    'method' => 'POST',
+                    'url'    => 'https://u.y.qq.com/cgi-bin/musicu.fcg',
+                    'body'   => json_encode(array(
+                        'comm' => array(
+                            'ct' => '19',
+                            'cv' => '1873',
+                            'uin' => '0',
+                        ),
+                        'req_1' => array(
+                            'method' => 'get_song_detail_yqq',
+                            'module' => 'music.pf_song_detail_svr',
+                            'param' => array(
+                                'song_type' => 0,
+                                'song_mid' => $id,
+                                'song_id' => ''
+                            )
+                        )
+                    )),
                     'decode' => 'tencent_url',
                 );
                 break;
@@ -486,49 +712,37 @@ class Meting
                 // 返回最终处理后的结果
                 return $decoded_result;
             case 'tencent':
-                if ($this->dwrc) {
-                    $api = array(
-                        'method' => 'POST',
-                        'url'    => 'https://u6.y.qq.com/cgi-bin/musicu.fcg',
-                        'body'   => json_encode(array(
-                            'comm' => array(
-                                '_channelid' => '0',
-                                '_os_version' => '6.2.9200-2',
-                                'authst' => '',
-                                'ct' => '19',
-                                'cv' => '1873',
-                                'patch' => '118',
-                                'psrf_access_token_expiresAt' => 0,
-                                'psrf_qqaccess_token' => '',
-                                'psrf_qqopenid' => '',
-                                'psrf_qqunionid' => '',
-                                'tmeAppID' => 'qqmusic',
-                                'tmeLoginType' => 2,
-                                'uin' => '0',
-                                'wid' => '0',
-                            ),
-                            'req_1' => array(
-                                'method' => 'GetPlayLyricInfo',
-                                'module' => 'music.musichallSong.PlayLyricInfo',
-                                'param' => array(
-                                    'songMID' => $id,
-                                    'qrc' => $this->dwrc ? 1 : 0,
-                                ),
-                            )
-                        )),
-                        'decode' => 'tencent_lyric_qrc',
-                    );
-                } else {
-                    $api = array(
-                        'method' => 'GET',
-                        'url'    => 'https://c.y.qq.com/lyric/fcgi-bin/fcg_query_lyric_new.fcg',
-                        'body'   => array(
-                            'songmid' => $id,
-                            'g_tk'    => '5381',
+                $api = array(
+                    'method' => 'POST',
+                    'url'    => 'https://u6.y.qq.com/cgi-bin/musicu.fcg',
+                    'body'   => json_encode(array(
+                        'comm' => array(
+                            '_channelid' => '0',
+                            '_os_version' => '6.2.9200-2',
+                            'authst' => '',
+                            'ct' => '19',
+                            'cv' => '1873',
+                            'patch' => '118',
+                            'psrf_access_token_expiresAt' => 0,
+                            'psrf_qqaccess_token' => '',
+                            'psrf_qqopenid' => '',
+                            'psrf_qqunionid' => '',
+                            'tmeAppID' => 'qqmusic',
+                            'tmeLoginType' => 2,
+                            'uin' => '0',
+                            'wid' => '0',
                         ),
-                        'decode' => 'tencent_lyric',
-                    );
-                };
+                        'req_1' => array(
+                            'method' => 'GetPlayLyricInfo',
+                            'module' => 'music.musichallSong.PlayLyricInfo',
+                            'param' => array(
+                                'songMID' => $id,
+                                'qrc' => $this->dwrc ? 1 : 0,
+                            ),
+                        )
+                    )),
+                    'decode' => 'tencent_lyric_qrc',
+                );
                 break;
         }
         return $this->exec($api);
@@ -572,7 +786,7 @@ class Meting
                 );
             case 'tencent':
                 return array(
-                    'Referer'         => 'https://y.qq.com',
+                    'Referer'         => 'https://y.qq.com/',
                     'Cookie'          => 'pgv_pvi=22038528; pgv_si=s3156287488; pgv_pvid=5535248600; yplayer_open=1; ts_last=y.qq.com/portal/player.html; ts_uid=4847550686; yq_index=0; qqmusic_fromtag=66; player_exist=1',
                     'User-Agent'      => 'QQ%E9%9F%B3%E4%B9%90/54409 CFNetwork/901.1 Darwin/17.6.0 (x86_64)',
                     'Accept'          => '*/*',
@@ -699,7 +913,7 @@ class Meting
             $url = array(
                 'url'  => $data['data'][0]['url'],
                 'size' => $data['data'][0]['size'],
-                'br'   => $data['data'][0]['br'] / 999999,
+                'br'   => $data['data'][0]['br'] / 1000,
             );
         } else {
             $url = array(
@@ -715,6 +929,11 @@ class Meting
     private function tencent_url($result)
     {
         $data = json_decode($result, true);
+        if (isset($data['req_1']['data']['track_info'])) {
+            $track = $data['req_1']['data']['track_info'];
+        } else {
+            $track = $data['data'][0];
+        }
         $guid = mt_rand() % 10000000000;
 
         $type = array(
@@ -750,30 +969,33 @@ class Meting
         );
 
         foreach ($type as $vo) {
-            $payload['req_0']['param']['songmid'][] = $data['data'][0]['mid'];
-            $payload['req_0']['param']['filename'][] = $vo[2] . $data['data'][0]['file']['media_mid'] . '.' . $vo[3];
-            $payload['req_0']['param']['songtype'][] = $data['data'][0]['type'];
+            $payload['req_0']['param']['songmid'][] = $track['mid'];
+            $payload['req_0']['param']['filename'][] = $vo[2] . $track['file']['media_mid'] . '.' . $vo[3];
+            $payload['req_0']['param']['songtype'][] = $track['type'];
         }
 
         $api = array(
-            'method' => 'GET',
-            'url'    => 'https://u6.y.qq.com/cgi-bin/musicu.fcg',
-            'body'   => array(
-                'format'      => 'json',
-                'platform'    => 'yqq.json',
-                'needNewCode' => 0,
-                'data'        => json_encode($payload),
-            ),
+            'method' => 'POST',
+            'url'    => 'https://u.y.qq.com/cgi-bin/musicu.fcg',
+            'body'   => json_encode(array(
+                'comm' => array(
+                    'ct' => '19',
+                    'cv' => '1873',
+                    'uin' => '0',
+                ),
+                'req_0' => $payload['req_0']
+            )),
         );
         $response = json_decode($this->exec($api), true);
         $vkeys = $response['req_0']['data']['midurlinfo'];
 
         foreach ($type as $index => $vo) {
-            if ($data['data'][0]['file'][$vo[0]] && $vo[1] <= $this->temp['br']) {
+            if (isset($track['file'][$vo[0]]) && $track['file'][$vo[0]] && $vo[1] <= $this->temp['br']) {
                 if (!empty($vkeys[$index]['vkey'])) {
+                    $sip = isset($response['req_0']['data']['sip'][0]) ? $response['req_0']['data']['sip'][0] : 'https://dl.stream.qqmusic.qq.com/';
                     $url = array(
-                        'url'  => $response['req_0']['data']['sip'][0] . $vkeys[$index]['purl'],
-                        'size' => $data['data'][0]['file'][$vo[0]],
+                        'url'  => $sip . $vkeys[$index]['purl'],
+                        'size' => $track['file'][$vo[0]],
                         'br'   => $vo[1],
                     );
                     break;
@@ -827,8 +1049,8 @@ class Meting
         $lrc = $result['req_1']['data']['lyric'];
         if ($result['req_1']['data']['qrc'] == 0) {
             return json_encode(array(
-                'lyric'  => base64_decode($lrc),
-                'tlyric' => '',
+                'lyric'  => isset($result['req_1']['data']['lyric']) && $result['req_1']['data']['lyric'] ? base64_decode($result['req_1']['data']['lyric']) : '',
+                'tlyric' => isset($result['req_1']['data']['trans']) && $result['req_1']['data']['trans'] ? base64_decode($result['req_1']['data']['trans']) : '',
             ), JSON_UNESCAPED_UNICODE);
         }
         $decoder = new Decoder();
@@ -842,7 +1064,11 @@ class Meting
 
     private function tencent_lyric($result)
     {
-        $result = substr($result, 18, -1);
+        $result = trim($result);
+        if (substr($result, 0, 1) !== '{') {
+            $result = preg_replace('/^\w+\(/', '', $result);
+            $result = preg_replace('/\)$/', '', $result);
+        }
         $result = json_decode($result, true);
         $data = array(
             'lyric'  => isset($result['lyric']) ? base64_decode($result['lyric']) : '',
@@ -862,6 +1088,9 @@ class Meting
             'pic_id'   => isset($data['al']['pic_str']) ? $data['al']['pic_str'] : $data['al']['pic'],
             'url_id'   => $data['id'],
             'lyric_id' => $data['id'],
+            'duration' => $data['dt'] ?? null,
+            'mv_id'    => $data['mv'] ?? null,
+            'fee'      => $data['fee'] ?? null,
             'source'   => 'netease',
         );
         if (isset($data['al']['picUrl'])) {
@@ -880,18 +1109,34 @@ class Meting
         if (isset($data['musicData'])) {
             $data = $data['musicData'];
         }
+
+        $mid = $data['mid'] ?? ($data['songmid'] ?? '');
+        $name = $data['name'] ?? ($data['songname'] ?? '');
+
+        $album_name = $data['album']['title'] ?? ($data['album']['name'] ?? ($data['albumname'] ?? ''));
+        $album_mid = $data['album']['mid'] ?? ($data['albummid'] ?? '');
+
+        $interval = $data['interval'] ?? null;
+        $mv_id = $data['mv']['vid'] ?? ($data['vid'] ?? null);
+        $fee = $data['pay']['payplay'] ?? ($data['pay']['pay_play'] ?? null);
+
         $result = array(
-            'id'       => $data['mid'],
-            'name'     => $data['name'],
+            'id'       => $mid,
+            'name'     => $name,
             'artist'   => array(),
-            'album'    => trim($data['album']['title']),
-            'pic_id'   => $data['album']['mid'],
-            'url_id'   => $data['mid'],
-            'lyric_id' => $data['mid'],
+            'album'    => trim($album_name),
+            'pic_id'   => $album_mid,
+            'url_id'   => $mid,
+            'lyric_id' => $mid,
+            'duration' => $interval,
+            'mv_id'    => $mv_id,
+            'fee'      => $fee,
             'source'   => 'tencent',
         );
-        foreach ($data['singer'] as $vo) {
-            $result['artist'][] = $vo['name'];
+        if (isset($data['singer'])) {
+            foreach ($data['singer'] as $vo) {
+                $result['artist'][] = $vo['name'];
+            }
         }
 
         return $result;

--- a/src/QMCookie.php
+++ b/src/QMCookie.php
@@ -1,0 +1,3 @@
+<?php if (!defined('METING_API')) die('Access Denied');
+$QMCookie = '';
+?>

--- a/src/QrcDecode.php
+++ b/src/QrcDecode.php
@@ -1,0 +1,1061 @@
+<?php
+namespace QrcDecode;
+
+// source from:
+// https://github.com/luren-dc/QQMusicApi/blob/main/qqmusic_api/utils/tripledes.py
+// https://github.com/luren-dc/QQMusicApi/blob/main/qqmusic_api/utils/common.py#L86
+class Decoder
+{
+    public function __construct() {}
+    private $en_mode = 1;
+    private $de_mode = 0;
+
+    private $sbox = [
+        # sbox1
+        [
+            14,
+            4,
+            13,
+            1,
+            2,
+            15,
+            11,
+            8,
+            3,
+            10,
+            6,
+            12,
+            5,
+            9,
+            0,
+            7,
+            0,
+            15,
+            7,
+            4,
+            14,
+            2,
+            13,
+            1,
+            10,
+            6,
+            12,
+            11,
+            9,
+            5,
+            3,
+            8,
+            4,
+            1,
+            14,
+            8,
+            13,
+            6,
+            2,
+            11,
+            15,
+            12,
+            9,
+            7,
+            3,
+            10,
+            5,
+            0,
+            15,
+            12,
+            8,
+            2,
+            4,
+            9,
+            1,
+            7,
+            5,
+            11,
+            3,
+            14,
+            10,
+            0,
+            6,
+            13,
+        ],
+
+        # sbox2
+        [
+            15,
+            1,
+            8,
+            14,
+            6,
+            11,
+            3,
+            4,
+            9,
+            7,
+            2,
+            13,
+            12,
+            0,
+            5,
+            10,
+            3,
+            13,
+            4,
+            7,
+            15,
+            2,
+            8,
+            15,
+            12,
+            0,
+            1,
+            10,
+            6,
+            9,
+            11,
+            5,
+            0,
+            14,
+            7,
+            11,
+            10,
+            4,
+            13,
+            1,
+            5,
+            8,
+            12,
+            6,
+            9,
+            3,
+            2,
+            15,
+            13,
+            8,
+            10,
+            1,
+            3,
+            15,
+            4,
+            2,
+            11,
+            6,
+            7,
+            12,
+            0,
+            5,
+            14,
+            9,
+        ],
+
+        # sbox3
+        [
+            10,
+            0,
+            9,
+            14,
+            6,
+            3,
+            15,
+            5,
+            1,
+            13,
+            12,
+            7,
+            11,
+            4,
+            2,
+            8,
+            13,
+            7,
+            0,
+            9,
+            3,
+            4,
+            6,
+            10,
+            2,
+            8,
+            5,
+            14,
+            12,
+            11,
+            15,
+            1,
+            13,
+            6,
+            4,
+            9,
+            8,
+            15,
+            3,
+            0,
+            11,
+            1,
+            2,
+            12,
+            5,
+            10,
+            14,
+            7,
+            1,
+            10,
+            13,
+            0,
+            6,
+            9,
+            8,
+            7,
+            4,
+            15,
+            14,
+            3,
+            11,
+            5,
+            2,
+            12,
+        ],
+
+        # sbox4
+        [
+            7,
+            13,
+            14,
+            3,
+            0,
+            6,
+            9,
+            10,
+            1,
+            2,
+            8,
+            5,
+            11,
+            12,
+            4,
+            15,
+            13,
+            8,
+            11,
+            5,
+            6,
+            15,
+            0,
+            3,
+            4,
+            7,
+            2,
+            12,
+            1,
+            10,
+            14,
+            9,
+            10,
+            6,
+            9,
+            0,
+            12,
+            11,
+            7,
+            13,
+            15,
+            1,
+            3,
+            14,
+            5,
+            2,
+            8,
+            4,
+            3,
+            15,
+            0,
+            6,
+            10,
+            10,
+            13,
+            8,
+            9,
+            4,
+            5,
+            11,
+            12,
+            7,
+            2,
+            14,
+        ],
+
+        # sbox5
+        [
+            2,
+            12,
+            4,
+            1,
+            7,
+            10,
+            11,
+            6,
+            8,
+            5,
+            3,
+            15,
+            13,
+            0,
+            14,
+            9,
+            14,
+            11,
+            2,
+            12,
+            4,
+            7,
+            13,
+            1,
+            5,
+            0,
+            15,
+            10,
+            3,
+            9,
+            8,
+            6,
+            4,
+            2,
+            1,
+            11,
+            10,
+            13,
+            7,
+            8,
+            15,
+            9,
+            12,
+            5,
+            6,
+            3,
+            0,
+            14,
+            11,
+            8,
+            12,
+            7,
+            1,
+            14,
+            2,
+            13,
+            6,
+            15,
+            0,
+            9,
+            10,
+            4,
+            5,
+            3,
+        ],
+
+        # sbox6
+        [
+            12,
+            1,
+            10,
+            15,
+            9,
+            2,
+            6,
+            8,
+            0,
+            13,
+            3,
+            4,
+            14,
+            7,
+            5,
+            11,
+            10,
+            15,
+            4,
+            2,
+            7,
+            12,
+            9,
+            5,
+            6,
+            1,
+            13,
+            14,
+            0,
+            11,
+            3,
+            8,
+            9,
+            14,
+            15,
+            5,
+            2,
+            8,
+            12,
+            3,
+            7,
+            0,
+            4,
+            10,
+            1,
+            13,
+            11,
+            6,
+            4,
+            3,
+            2,
+            12,
+            9,
+            5,
+            15,
+            10,
+            11,
+            14,
+            1,
+            7,
+            6,
+            0,
+            8,
+            13,
+        ],
+
+        # sbox7
+        [
+            4,
+            11,
+            2,
+            14,
+            15,
+            0,
+            8,
+            13,
+            3,
+            12,
+            9,
+            7,
+            5,
+            10,
+            6,
+            1,
+            13,
+            0,
+            11,
+            7,
+            4,
+            9,
+            1,
+            10,
+            14,
+            3,
+            5,
+            12,
+            2,
+            15,
+            8,
+            6,
+            1,
+            4,
+            11,
+            13,
+            12,
+            3,
+            7,
+            14,
+            10,
+            15,
+            6,
+            8,
+            0,
+            5,
+            9,
+            2,
+            6,
+            11,
+            13,
+            8,
+            1,
+            4,
+            10,
+            7,
+            9,
+            5,
+            0,
+            15,
+            14,
+            2,
+            3,
+            12,
+        ],
+
+        # sbox8
+        [
+            13,
+            2,
+            8,
+            4,
+            6,
+            15,
+            11,
+            1,
+            10,
+            9,
+            3,
+            14,
+            5,
+            0,
+            12,
+            7,
+            1,
+            15,
+            13,
+            8,
+            10,
+            3,
+            7,
+            4,
+            12,
+            5,
+            6,
+            11,
+            0,
+            14,
+            9,
+            2,
+            7,
+            11,
+            4,
+            1,
+            9,
+            12,
+            14,
+            2,
+            0,
+            6,
+            10,
+            13,
+            15,
+            3,
+            5,
+            8,
+            2,
+            1,
+            14,
+            7,
+            4,
+            10,
+            8,
+            13,
+            15,
+            12,
+            9,
+            0,
+            3,
+            5,
+            6,
+            11,
+        ],
+    ];
+
+    private function bitnum(string $a, int $b, int $c): int
+    {
+        $index = intdiv($b, 32) * 4 + 3 - intdiv($b % 32, 8);
+        $byte = ord($a[$index]);
+        $shift = 7 - ($b % 8);
+        return (($byte >> $shift) & 1) << $c;
+    }
+
+    /**
+     * 从整数中提取指定位置的位,并左移指定偏移量。
+     *
+     * @param int $a 整数
+     * @param int $b 要提取的位索引
+     * @param int $c 位提取后的偏移量
+     * @return int 提取后的位
+     */
+    private function bitnum_intr(int $a, int $b, int $c): int
+    {
+        return (($a >> 31 - $b) & 1) << $c;
+    }
+
+    private function bitnum_intl(int $a, int $b, int $c): int
+    {
+        return (($a << $b) & 0x80000000) >> $c;
+    }
+
+    private function sbox_bit(int $a): int
+    {
+        // 对输入整数进行位运算,重新组合位。
+        // :param a: 整数
+        // :return: 重新组合后的位
+        return ($a & 32) | (($a & 31) >> 1) | (($a & 1) << 4);
+    }
+
+    private function initial_permutation(string $input_data): array
+    {
+        $s0 =
+            $this->bitnum($input_data, 57, 31) |
+            $this->bitnum($input_data, 49, 30) |
+            $this->bitnum($input_data, 41, 29) |
+            $this->bitnum($input_data, 33, 28) |
+            $this->bitnum($input_data, 25, 27) |
+            $this->bitnum($input_data, 17, 26) |
+            $this->bitnum($input_data, 9, 25) |
+            $this->bitnum($input_data, 1, 24) |
+            $this->bitnum($input_data, 59, 23) |
+            $this->bitnum($input_data, 51, 22) |
+            $this->bitnum($input_data, 43, 21) |
+            $this->bitnum($input_data, 35, 20) |
+            $this->bitnum($input_data, 27, 19) |
+            $this->bitnum($input_data, 19, 18) |
+            $this->bitnum($input_data, 11, 17) |
+            $this->bitnum($input_data, 3, 16) |
+            $this->bitnum($input_data, 61, 15) |
+            $this->bitnum($input_data, 53, 14) |
+            $this->bitnum($input_data, 45, 13) |
+            $this->bitnum($input_data, 37, 12) |
+            $this->bitnum($input_data, 29, 11) |
+            $this->bitnum($input_data, 21, 10) |
+            $this->bitnum($input_data, 13, 9) |
+            $this->bitnum($input_data, 5, 8) |
+            $this->bitnum($input_data, 63, 7) |
+            $this->bitnum($input_data, 55, 6) |
+            $this->bitnum($input_data, 47, 5) |
+            $this->bitnum($input_data, 39, 4) |
+            $this->bitnum($input_data, 31, 3) |
+            $this->bitnum($input_data, 23, 2) |
+            $this->bitnum($input_data, 15, 1) |
+            $this->bitnum($input_data, 7, 0);
+
+        $s1 =
+            $this->bitnum($input_data, 56, 31) |
+            $this->bitnum($input_data, 48, 30) |
+            $this->bitnum($input_data, 40, 29) |
+            $this->bitnum($input_data, 32, 28) |
+            $this->bitnum($input_data, 24, 27) |
+            $this->bitnum($input_data, 16, 26) |
+            $this->bitnum($input_data, 8, 25) |
+            $this->bitnum($input_data, 0, 24) |
+            $this->bitnum($input_data, 58, 23) |
+            $this->bitnum($input_data, 50, 22) |
+            $this->bitnum($input_data, 42, 21) |
+            $this->bitnum($input_data, 34, 20) |
+            $this->bitnum($input_data, 26, 19) |
+            $this->bitnum($input_data, 18, 18) |
+            $this->bitnum($input_data, 10, 17) |
+            $this->bitnum($input_data, 2, 16) |
+            $this->bitnum($input_data, 60, 15) |
+            $this->bitnum($input_data, 52, 14) |
+            $this->bitnum($input_data, 44, 13) |
+            $this->bitnum($input_data, 36, 12) |
+            $this->bitnum($input_data, 28, 11) |
+            $this->bitnum($input_data, 20, 10) |
+            $this->bitnum($input_data, 12, 9) |
+            $this->bitnum($input_data, 4, 8) |
+            $this->bitnum($input_data, 62, 7) |
+            $this->bitnum($input_data, 54, 6) |
+            $this->bitnum($input_data, 46, 5) |
+            $this->bitnum($input_data, 38, 4) |
+            $this->bitnum($input_data, 30, 3) |
+            $this->bitnum($input_data, 22, 2) |
+            $this->bitnum($input_data, 14, 1) |
+            $this->bitnum($input_data, 6, 0);
+
+        return [$s0, $s1];
+    }
+
+    private function inverse_permutation(int $s0, int $s1): string
+    {
+        $data = array_fill(0, 8, 0);
+
+        $data[3] =
+            $this->bitnum_intr($s1, 7, 7) |
+            $this->bitnum_intr($s0, 7, 6) |
+            $this->bitnum_intr($s1, 15, 5) |
+            $this->bitnum_intr($s0, 15, 4) |
+            $this->bitnum_intr($s1, 23, 3) |
+            $this->bitnum_intr($s0, 23, 2) |
+            $this->bitnum_intr($s1, 31, 1) |
+            $this->bitnum_intr($s0, 31, 0);
+
+        $data[2] =
+            $this->bitnum_intr($s1, 6, 7) |
+            $this->bitnum_intr($s0, 6, 6) |
+            $this->bitnum_intr($s1, 14, 5) |
+            $this->bitnum_intr($s0, 14, 4) |
+            $this->bitnum_intr($s1, 22, 3) |
+            $this->bitnum_intr($s0, 22, 2) |
+            $this->bitnum_intr($s1, 30, 1) |
+            $this->bitnum_intr($s0, 30, 0);
+
+        $data[1] =
+            $this->bitnum_intr($s1, 5, 7) |
+            $this->bitnum_intr($s0, 5, 6) |
+            $this->bitnum_intr($s1, 13, 5) |
+            $this->bitnum_intr($s0, 13, 4) |
+            $this->bitnum_intr($s1, 21, 3) |
+            $this->bitnum_intr($s0, 21, 2) |
+            $this->bitnum_intr($s1, 29, 1) |
+            $this->bitnum_intr($s0, 29, 0);
+
+        $data[0] =
+            $this->bitnum_intr($s1, 4, 7) |
+            $this->bitnum_intr($s0, 4, 6) |
+            $this->bitnum_intr($s1, 12, 5) |
+            $this->bitnum_intr($s0, 12, 4) |
+            $this->bitnum_intr($s1, 20, 3) |
+            $this->bitnum_intr($s0, 20, 2) |
+            $this->bitnum_intr($s1, 28, 1) |
+            $this->bitnum_intr($s0, 28, 0);
+
+        $data[7] =
+            $this->bitnum_intr($s1, 3, 7) |
+            $this->bitnum_intr($s0, 3, 6) |
+            $this->bitnum_intr($s1, 11, 5) |
+            $this->bitnum_intr($s0, 11, 4) |
+            $this->bitnum_intr($s1, 19, 3) |
+            $this->bitnum_intr($s0, 19, 2) |
+            $this->bitnum_intr($s1, 27, 1) |
+            $this->bitnum_intr($s0, 27, 0);
+
+        $data[6] =
+            $this->bitnum_intr($s1, 2, 7) |
+            $this->bitnum_intr($s0, 2, 6) |
+            $this->bitnum_intr($s1, 10, 5) |
+            $this->bitnum_intr($s0, 10, 4) |
+            $this->bitnum_intr($s1, 18, 3) |
+            $this->bitnum_intr($s0, 18, 2) |
+            $this->bitnum_intr($s1, 26, 1) |
+            $this->bitnum_intr($s0, 26, 0);
+
+        $data[5] =
+            $this->bitnum_intr($s1, 1, 7) |
+            $this->bitnum_intr($s0, 1, 6) |
+            $this->bitnum_intr($s1, 9, 5) |
+            $this->bitnum_intr($s0, 9, 4) |
+            $this->bitnum_intr($s1, 17, 3) |
+            $this->bitnum_intr($s0, 17, 2) |
+            $this->bitnum_intr($s1, 25, 1) |
+            $this->bitnum_intr($s0, 25, 0);
+
+        $data[4] =
+            $this->bitnum_intr($s1, 0, 7) |
+            $this->bitnum_intr($s0, 0, 6) |
+            $this->bitnum_intr($s1, 8, 5) |
+            $this->bitnum_intr($s0, 8, 4) |
+            $this->bitnum_intr($s1, 16, 3) |
+            $this->bitnum_intr($s0, 16, 2) |
+            $this->bitnum_intr($s1, 24, 1) |
+            $this->bitnum_intr($s0, 24, 0);
+
+        return pack("C8", ...$data);
+    }
+
+    private function f(int $state, array $key): int
+    {
+        // global $sbox;
+        $t1 =
+            $this->bitnum_intl($state, 31, 0) |
+            (($state & 0xf0000000) >> 1) |
+            $this->bitnum_intl($state, 4, 5) |
+            $this->bitnum_intl($state, 3, 6) |
+            (($state & 0x0f000000) >> 3) |
+            $this->bitnum_intl($state, 8, 11) |
+            $this->bitnum_intl($state, 7, 12) |
+            (($state & 0x00f00000) >> 5) |
+            $this->bitnum_intl($state, 12, 17) |
+            $this->bitnum_intl($state, 11, 18) |
+            (($state & 0x000f0000) >> 7) |
+            $this->bitnum_intl($state, 16, 23);
+
+        $t2 =
+            $this->bitnum_intl($state, 15, 0) |
+            (($state & 0x0000f000) << 15) |
+            $this->bitnum_intl($state, 20, 5) |
+            $this->bitnum_intl($state, 19, 6) |
+            (($state & 0x00000f00) << 13) |
+            $this->bitnum_intl($state, 24, 11) |
+            $this->bitnum_intl($state, 23, 12) |
+            (($state & 0x000000f0) << 11) |
+            $this->bitnum_intl($state, 28, 17) |
+            $this->bitnum_intl($state, 27, 18) |
+            (($state & 0x0000000f) << 9) |
+            $this->bitnum_intl($state, 0, 23);
+
+        $lrgstate = [
+            ($t1 >> 24) & 0x000000ff,
+            ($t1 >> 16) & 0x000000ff,
+            ($t1 >> 8) & 0x000000ff,
+            ($t2 >> 24) & 0x000000ff,
+            ($t2 >> 16) & 0x000000ff,
+            ($t2 >> 8) & 0x000000ff,
+        ];
+
+        for ($i = 0; $i < 6; $i++) {
+            $lrgstate[$i] ^= $key[$i];
+        }
+
+        $state =
+            ($this->sbox[0][$this->sbox_bit($lrgstate[0] >> 2)] << 28) |
+            ($this->sbox[1][
+                $this->sbox_bit((($lrgstate[0] & 0x03) << 4) | ($lrgstate[1] >> 4))
+            ] <<
+                24) |
+            ($this->sbox[2][
+                $this->sbox_bit((($lrgstate[1] & 0x0f) << 2) | ($lrgstate[2] >> 6))
+            ] <<
+                20) |
+            ($this->sbox[3][$this->sbox_bit($lrgstate[2] & 0x3f)] << 16) |
+            ($this->sbox[4][$this->sbox_bit($lrgstate[3] >> 2)] << 12) |
+            ($this->sbox[5][
+                $this->sbox_bit((($lrgstate[3] & 0x03) << 4) | ($lrgstate[4] >> 4))
+            ] <<
+                8) |
+            ($this->sbox[6][
+                $this->sbox_bit((($lrgstate[4] & 0x0f) << 2) | ($lrgstate[5] >> 6))
+            ] <<
+                4) |
+            $this->sbox[7][$this->sbox_bit($lrgstate[5] & 0x3f)];
+
+        return $this->bitnum_intl($state, 15, 0) |
+            $this->bitnum_intl($state, 6, 1) |
+            $this->bitnum_intl($state, 19, 2) |
+            $this->bitnum_intl($state, 20, 3) |
+            $this->bitnum_intl($state, 28, 4) |
+            $this->bitnum_intl($state, 11, 5) |
+            $this->bitnum_intl($state, 27, 6) |
+            $this->bitnum_intl($state, 16, 7) |
+            $this->bitnum_intl($state, 0, 8) |
+            $this->bitnum_intl($state, 14, 9) |
+            $this->bitnum_intl($state, 22, 10) |
+            $this->bitnum_intl($state, 25, 11) |
+            $this->bitnum_intl($state, 4, 12) |
+            $this->bitnum_intl($state, 17, 13) |
+            $this->bitnum_intl($state, 30, 14) |
+            $this->bitnum_intl($state, 9, 15) |
+            $this->bitnum_intl($state, 1, 16) |
+            $this->bitnum_intl($state, 7, 17) |
+            $this->bitnum_intl($state, 23, 18) |
+            $this->bitnum_intl($state, 13, 19) |
+            $this->bitnum_intl($state, 31, 20) |
+            $this->bitnum_intl($state, 26, 21) |
+            $this->bitnum_intl($state, 2, 22) |
+            $this->bitnum_intl($state, 8, 23) |
+            $this->bitnum_intl($state, 18, 24) |
+            $this->bitnum_intl($state, 12, 25) |
+            $this->bitnum_intl($state, 29, 26) |
+            $this->bitnum_intl($state, 5, 27) |
+            $this->bitnum_intl($state, 21, 28) |
+            $this->bitnum_intl($state, 10, 29) |
+            $this->bitnum_intl($state, 3, 30) |
+            $this->bitnum_intl($state, 24, 31);
+    }
+
+    private function acrypt(string $input_data, array $key): string
+    {
+        list($s0, $s1) = $this->initial_permutation($input_data); // 初始置换
+
+        for ($idx = 0; $idx < 15; $idx++) {
+            // 15轮迭代
+            $previous_s1 = $s1;
+            $s1 = $this->f($s1, $key[$idx]) ^ $s0;
+            $s0 = $previous_s1;
+        }
+        $s0 = $this->f($s1, $key[15]) ^ $s0; // 第15轮
+
+        return $this->inverse_permutation($s0, $s1); // 逆置换
+    }
+
+    private function key_schedule(string $key, int $mode): array
+    {
+        $schedule = array_fill(0, 16, array_fill(0, 6, 0));
+        $key_rnd_shift = [1, 1, 2, 2, 2, 2, 2, 2, 1, 2, 2, 2, 2, 2, 2, 1];
+        $key_perm_c = [
+            56,
+            48,
+            40,
+            32,
+            24,
+            16,
+            8,
+            0,
+            57,
+            49,
+            41,
+            33,
+            25,
+            17,
+            9,
+            1,
+            58,
+            50,
+            42,
+            34,
+            26,
+            18,
+            10,
+            2,
+            59,
+            51,
+            43,
+            35,
+        ];
+        $key_perm_d = [
+            62,
+            54,
+            46,
+            38,
+            30,
+            22,
+            14,
+            6,
+            61,
+            53,
+            45,
+            37,
+            29,
+            21,
+            13,
+            5,
+            60,
+            52,
+            44,
+            36,
+            28,
+            20,
+            12,
+            4,
+            27,
+            19,
+            11,
+            3,
+        ];
+        $key_compression = [
+            13,
+            16,
+            10,
+            23,
+            0,
+            4,
+            2,
+            27,
+            14,
+            5,
+            20,
+            9,
+            22,
+            18,
+            11,
+            3,
+            25,
+            7,
+            15,
+            6,
+            26,
+            19,
+            12,
+            1,
+            40,
+            51,
+            30,
+            36,
+            46,
+            54,
+            29,
+            39,
+            50,
+            44,
+            32,
+            47,
+            43,
+            48,
+            38,
+            55,
+            33,
+            52,
+            45,
+            41,
+            49,
+            35,
+            28,
+            31,
+        ];
+
+        $c = 0;
+        for ($i = 0; $i < 28; $i++) {
+            $c += $this->bitnum($key, $key_perm_c[$i], 31 - $i);
+        }
+        $d = 0;
+        for ($i = 0; $i < 28; $i++) {
+            $d += $this->bitnum($key, $key_perm_d[$i], 31 - $i);
+        }
+
+        for ($i = 0; $i < 16; $i++) {
+            $shift = $key_rnd_shift[$i];
+            $c = (($c << $shift) | ($c >> 28 - $shift)) & 0xfffffff0;
+            $d = (($d << $shift) | ($d >> 28 - $shift)) & 0xfffffff0;
+
+            $togen = $mode === 0 ? 15 - $i : $i;
+
+            for ($j = 0; $j < 6; $j++) {
+                $schedule[$togen][$j] = 0;
+            }
+
+            for ($j = 0; $j < 24; $j++) {
+                $schedule[$togen][intdiv($j, 8)] |= $this->bitnum_intr(
+                    $c,
+                    $key_compression[$j],
+                    7 - ($j % 8)
+                );
+            }
+
+            for ($j = 24; $j < 48; $j++) {
+                $schedule[$togen][intdiv($j, 8)] |= $this->bitnum_intr(
+                    $d,
+                    $key_compression[$j] - 27,
+                    7 - ($j % 8)
+                );
+            }
+        }
+        return $schedule;
+    }
+
+    private function tripledes_key_setup(string $key, int $mode): array
+    {
+        // global $en_mode, $de_mode;
+        if ($mode === $this->en_mode) {
+            return [
+                $this->key_schedule(substr($key, 0), $this->en_mode),
+                $this->key_schedule(substr($key, 8), $this->de_mode),
+                $this->key_schedule(substr($key, 16), $this->en_mode),
+            ];
+        }
+        return [
+            $this->key_schedule(substr($key, 16), $this->de_mode),
+            $this->key_schedule(substr($key, 8), $this->en_mode),
+            $this->key_schedule(substr($key, 0), $this->de_mode),
+        ];
+    }
+
+    private function tripledes_crypt(string $data, array $keys): string
+    {
+        for ($i = 0; $i < 3; $i++) {
+            $data = $this->acrypt($data, $keys[$i]);
+        }
+        return $data;
+    }
+
+    public function decode(string $hex): string
+    {
+        $schedule = $this->tripledes_key_setup(
+            "!@#)(*$%123ZXC!@!@#)(NHL",
+            $this->de_mode
+        );
+        $data = "";
+        $bin = hex2bin($hex);
+        for ($i = 0, $len = strlen($bin); $i < $len; $i += 8) {
+            $data .= $this->tripledes_crypt(substr($bin, $i, 8), $schedule);
+        }
+        return zlib_decode($data);
+    }
+}
+?>

--- a/src/RefreshQMCookie.py
+++ b/src/RefreshQMCookie.py
@@ -1,0 +1,328 @@
+import re
+import time
+import json
+import requests
+from pathlib import Path
+import logging
+import os
+import sys
+
+isPackaged: bool = not sys.argv[0].endswith('.py')
+
+# 配置日志
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler()
+    ]
+)
+
+# 配置文件路径
+if isPackaged:
+    exe_path = Path(sys.argv[0]).resolve()
+    base_path = exe_path.parent
+    os.chdir(base_path)
+    BASE_DIR = base_path
+else:
+    BASE_DIR = Path(__file__).resolve().parent
+
+INDEX_PHP = BASE_DIR.parent / "index.php"
+COOKIE_PHP = BASE_DIR / "QMCookie.php"
+
+def extract_index_cookie():
+    try:
+        with open(INDEX_PHP, "r", encoding="utf-8") as f:
+            content = f.read()
+        logging.debug(f"读取的PHP文件内容片段: {content[:500]}...")
+        # 更可靠的正则表达式匹配 - 直接匹配 Cookie 字符串
+        pattern = r"else if \(server == 'tencent' && \$tencent_cookie == 'local'\)\s*\{\s*\$api->cookie\('([^']+)'\)"
+        match = re.search(pattern, content)
+        if match:
+            logging.info("成功匹配到内嵌 Cookie")
+            return match.group(1)
+        # 备用匹配模式 - 匹配整个 Cookie 字符串
+        pattern_alt = r"\$api->cookie\('(pgv_pvid=[^']+)'\)"
+        match_alt = re.search(pattern_alt, content)
+        if match_alt:
+            logging.info("使用备用模式匹配到内嵌 Cookie")
+            return match_alt.group(1)
+        logging.warning("无法匹配内嵌 Cookie 字符串")
+        return None
+    except Exception as e:
+        logging.error(f"提取主文件 Cookie 失败: {str(e)}")
+        return None
+
+def parse_cookie(cookie_str):
+    """解析 Cookie 字符串为字典"""
+    if not cookie_str:
+        return {}
+    try:
+        cookie_dict = {}
+        for item in cookie_str.split("; "):
+            if "=" in item:
+                key, value = item.split("=", 1)
+                cookie_dict[key.strip()] = value.strip()
+        return cookie_dict
+    except Exception as e:
+        logging.error(f"解析 Cookie 失败: {str(e)}")
+        return {}
+
+def load_stored_cookie():
+    """读取存储的 Cookie 数据"""
+    try:
+        if not COOKIE_PHP.exists():
+            logging.warning(f"存储文件不存在: {COOKIE_PHP}")
+            return None
+        with open(COOKIE_PHP, "r", encoding="utf-8") as f:
+            content = f.read()
+        # 匹配存储的 Cookie 值
+        pattern = r"\$QMCookie\s*=\s*'([^']*)'"
+        match = re.search(pattern, content)
+        if match:
+            cookie_value = match.group(1)
+            logging.info(f"读取到存储的 Cookie: {cookie_value[:30]}...")  # 只显示前30个字符
+            return cookie_value
+        logging.warning("存储文件中未找到 Cookie 值")
+        return None
+    except Exception as e:
+        logging.error(f"读取存储的 Cookie 失败: {str(e)}")
+        return None
+
+def is_cookie_valid(cookie_str):
+    """检查 Cookie 是否有效"""
+    # 检查特殊值
+    if not cookie_str or cookie_str.lower() in ("", "null", "undefined", "local"):
+        logging.info(f"无效 Cookie: {cookie_str}")
+        return False
+    try:
+        cookie_dict = parse_cookie(cookie_str)
+        create_time = int(cookie_dict.get("psrf_musickey_createtime", "0") or 0)
+        current_time = int(time.time())
+        # 记录调试信息
+        logging.debug(f"Cookie 创建时间: {create_time}")
+        logging.debug(f"当前时间: {current_time}")
+        logging.debug(f"过期时间: {create_time + 86400}")
+        # 检查是否在有效期内（24小时）
+        if create_time <= 0:
+            logging.info("无效 Cookie: 缺少时间戳")
+            return False
+        if current_time >= (create_time + 86400):
+            logging.info(f"Cookie 已过期: {current_time - (create_time + 86400)}秒")
+            return False
+        logging.info("Cookie 有效")
+        return True
+    except Exception as e:
+        logging.error(f"验证 Cookie 有效性失败: {str(e)}")
+        return False
+
+def is_cookie_near_expiry(cookie_str):
+    """检查 Cookie 是否临近过期（超过20小时但未满24小时）"""
+    if not cookie_str:
+        return False
+    try:
+        cookie_dict = parse_cookie(cookie_str)
+        create_time = int(cookie_dict.get("psrf_musickey_createtime", "0") or 0)
+        current_time = int(time.time())
+        # 检查是否在临近过期状态
+        return (create_time > 0 and
+                current_time > (create_time + 72000) and  # 20小时
+                current_time < (create_time + 86400))     # 24小时
+    except Exception as e:
+        logging.error(f"检查 Cookie 过期状态失败: {str(e)}")
+        return False
+
+def renew_cookie(cookie_str):
+    """执行 Cookie 续签"""
+    if not cookie_str:
+        logging.warning("续签失败: 无有效 Cookie")
+        return None
+    try:
+        cookie_dict = parse_cookie(cookie_str)
+        url = "https://u6.y.qq.com/cgi-bin/musicu.fcg?format=json&inCharset=utf8&outCharset=utf8"
+        headers = {
+            "Referer": "https://y.qq.com/",
+            "Origin": "https://y.qq.com",
+            "Content-Type": "application/json",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+        }
+        # 构建请求体
+        payload = {
+            "code": 0,
+            "req1": {
+                "code": 0,
+                "module": "QQConnectLogin.LoginServer",
+                "method": "QQLogin",
+                "param": {
+                    "onlyNeedAccessToken": 0,
+                    "forceRefreshToken": 0,
+                    "psrf_qqopenid": cookie_dict.get("psrf_qqopenid", ""),
+                    "refresh_token": cookie_dict.get("psrf_qqrefresh_token", ""),
+                    "access_token": cookie_dict.get("psrf_qqaccess_token", ""),
+                    "expired_at": cookie_dict.get("psrf_access_token_expiresAt", ""),
+                    "musicid": int(cookie_dict.get("uin", "").strip('"')),
+                    "musickey": cookie_dict.get("qqmusic_key", ""),
+                    "musickeyCreateTime": int(cookie_dict.get("psrf_musickey_createtime", "0") or 0),
+                    "unionid": cookie_dict.get("psrf_qqunionid", ""),
+                    "str_musicid": cookie_dict.get("uin", ""),
+                    "encryptUin": cookie_dict.get("euin", "")
+                }
+            }
+        }
+        logging.info(f"发送续签请求到: {url}")
+        logging.debug(f"请求载荷: {json.dumps(payload, indent=2)}")
+        response = requests.post(
+            url,
+            json=payload,
+            headers=headers,
+            cookies=cookie_dict,
+            timeout=15
+        )
+        if response.status_code != 200:
+            logging.error(f"续签请求失败: HTTP {response.status_code}")
+            return None
+        data = response.json()
+        logging.debug(f"续签响应: {json.dumps(data, indent=2)}")
+        if data.get("code") == 0 and data["req1"].get("code") == 0:
+            logging.info("续签请求成功")
+            return data["req1"]["data"]
+        else:
+            logging.error(f"续签返回错误: {json.dumps(data, ensure_ascii=False)}")
+            return None
+    except Exception as e:
+        logging.error(f"续签过程中出错: {str(e)}")
+        return None
+
+def update_cookie_file(new_cookie_str):
+    """更新存储的 Cookie 文件"""
+    if not new_cookie_str:
+        logging.warning("跳过更新: 空 Cookie")
+        return
+    try:
+        # 确保目录存在
+        COOKIE_PHP.parent.mkdir(parents=True, exist_ok=True)
+        # 转义单引号防止破坏 PHP 结构
+        escaped_cookie = new_cookie_str.replace("'", "\\'")
+        php_content = f"""<?php if (!defined('METING_API')) die('Access Denied');
+$QMCookie = '{escaped_cookie}';
+?>"""
+        with open(COOKIE_PHP, "w", encoding="utf-8") as f:
+            f.write(php_content)
+        logging.info("存储的 Cookie 文件已更新")
+    except Exception as e:
+        logging.error(f"更新 Cookie 文件失败: {str(e)}")
+
+def update_cookie_with_data(original_cookie_str, new_data):
+    """用续签数据更新原始 Cookie"""
+    if not original_cookie_str or not new_data:
+        return original_cookie_str
+    try:
+        cookie_dict = parse_cookie(original_cookie_str)
+        # 更新关键字段
+        update_fields = {
+            "psrf_qqrefresh_token": new_data.get("refresh_token"),
+            "psrf_qqaccess_token": new_data.get("access_token"),
+            "qqmusic_key": new_data.get("musickey"),
+            "qm_keyst": new_data.get("musickey"),
+            "psrf_musickey_createtime": str(new_data.get("musickeyCreateTime", "")),
+            "psrf_qqunionid": new_data.get("unionid"),
+            "login_type": new_data.get("login_type")
+        }
+        # 只更新非空值
+        for key, value in update_fields.items():
+            if value and value != "0" and value != 0:
+                cookie_dict[key] = value
+        # 重新生成 Cookie 字符串
+        return "; ".join(f"{k}={v}" for k, v in cookie_dict.items())
+    except Exception as e:
+        logging.error(f"更新 Cookie 数据失败: {str(e)}")
+        return original_cookie_str
+
+def main():
+    logging.info(f" ")
+    logging.info(f" ")
+    logging.info(f" ")
+    logging.info(f"---------------")
+    logging.info(f"QQMusic Cookie 续签服务启动")
+    logging.info(f"")
+    logging.info(f"版本: 1.0.0")
+    logging.info(f"Made by NanoRocky")
+    logging.info(f"https://github.com/NanoRocky/QMusicCookieRefresh")
+    logging.info(f"---------------")
+    logging.info(f"INDEX_PHP 路径: {INDEX_PHP}")
+    logging.info(f"COOKIE_PHP 路径: {COOKIE_PHP}")
+    logging.info(f"当前工作目录: {BASE_DIR}")
+    logging.info(f"---------------")
+    while True:
+        try:
+            # 1. 读取存储的 Cookie
+            stored_cookie = load_stored_cookie()
+            # 2. 检查存储的 Cookie 是否有效
+            if stored_cookie and is_cookie_valid(stored_cookie):
+                logging.info("存储的 Cookie 有效")
+            else:
+                logging.warning("存储的 Cookie 无效或不存在")
+                # 3. 当存储的 Cookie 无效时，尝试从主 PHP 读取内嵌 Cookie
+                index_cookie = extract_index_cookie()
+                if index_cookie:
+                    logging.info(f"提取到内嵌 Cookie: {index_cookie[:50]}...")
+                    if is_cookie_valid(index_cookie):
+                        logging.info("内嵌 Cookie 有效，更新存储")
+                        update_cookie_file(index_cookie)
+                        stored_cookie = index_cookie
+                    else:
+                        logging.warning("内嵌 Cookie 无效")
+                else:
+                    logging.error("无法提取内嵌 Cookie")
+                if not stored_cookie or not is_cookie_valid(stored_cookie):
+                    logging.error("无有效 Cookie，等待1小时")
+                    time.sleep(3600)
+                    continue
+            # 4. 检查主文件 Cookie 是否更新
+            index_cookie = extract_index_cookie()
+            if index_cookie and index_cookie != stored_cookie and is_cookie_valid(index_cookie):
+                index_dict = parse_cookie(index_cookie)
+                stored_dict = parse_cookie(stored_cookie)
+                # 比较创建时间戳
+                index_time = int(index_dict.get("psrf_musickey_createtime", "0") or 0)
+                stored_time = int(stored_dict.get("psrf_musickey_createtime", "0") or 0)
+                if index_time > stored_time:
+                    update_cookie_file(index_cookie)
+                    logging.info("检测到更新的主文件 Cookie，覆盖存储")
+                    stored_cookie = index_cookie
+            # 5. 检查是否需要续签
+            if is_cookie_near_expiry(stored_cookie):
+                logging.info("Cookie 临近过期，执行续签...")
+                new_data = renew_cookie(stored_cookie)
+                if new_data:
+                    new_cookie = update_cookie_with_data(stored_cookie, new_data)
+                    update_cookie_file(new_cookie)
+                    logging.info("续签成功并更新存储")
+                    # 计算下次执行时间（20小时后）
+                    cookie_dict = parse_cookie(new_cookie)
+                    create_time = int(cookie_dict.get("psrf_musickey_createtime", "0") or 0)
+                    next_run = max(3600, (create_time + 72000) - time.time())
+                    logging.info(f"下次续签在 {next_run/3600:.1f} 小时后")
+                    time.sleep(next_run)
+                else:
+                    logging.warning("续签失败，1小时后重试")
+                    time.sleep(3600)
+            else:
+                # 6. 正常状态，计算等待时间
+                cookie_dict = parse_cookie(stored_cookie)
+                create_time = int(cookie_dict.get("psrf_musickey_createtime", "0") or 0)
+                if create_time > 0:
+                    # 计算距离20小时的时间
+                    wait_time = max(300, (create_time + 72000) - time.time())
+                    logging.info(f"Cookie 状态正常，{wait_time/3600:.1f} 小时后检查")
+                    time.sleep(wait_time)
+                else:
+                    logging.warning("缺少时间戳，1小时后检查")
+                    time.sleep(3600)
+        except Exception as e:
+            logging.critical(f"主循环发生错误: {str(e)}", exc_info=True)
+            logging.info("10分钟后重试")
+            time.sleep(600)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
这是一个能正常工作但非常 shi 的pr（）
------
     ·解除网易云音乐歌单1000首限制，更换网易云音乐歌单解析逻辑，使用歌单接口返回的 trackerIds 取得歌单内所有歌曲 ID ，再调用歌曲接口获取所有歌曲详细信息，解除歌单1k上限限制
     ·添加网易云音乐逐字歌词解析功能，使用 “yrc=true” 时优先解析逐字歌词。
     ·更新 Meting 至上游 1.5.11 。
     ·补全歌曲搜索功能。
     ·php 遗弃函数替代，支持 php 8+，并提高安全性。
     ·默认使用 HTTPS ，增强安全性。
     ·编辑默认页，添加新指令说明，并在默认页添加了一个 APlayer 小播放器（）。
     ·添加歌曲封面画质指定功能。
     ·添加指定音乐音质的功能。
------
目前在尝试为 QMusic 接口做 QRC 逐字歌词，但是卡在了 decode 解密。如果有大佬愿意的话，欢迎到克隆仓库的 test 分支来玩 DES ！（）